### PR TITLE
fix: use lazy gRPC connection to allow startup order flexibility

### DIFF
--- a/internal/controllerclient/client.go
+++ b/internal/controllerclient/client.go
@@ -3,7 +3,6 @@ package controllerclient
 import (
 	"context"
 	"fmt"
-	"time"
 
 	pb "github.com/isoboot/isoboot/api/controllerpb"
 	"google.golang.org/grpc"
@@ -23,17 +22,15 @@ type Client struct {
 	client pb.ControllerServiceClient
 }
 
-// New creates a new controller client
+// New creates a new controller client.
+// Connection is established lazily on first RPC call, allowing the HTTP server
+// to start before the controller is ready.
 func New(controllerAddr string) (*Client, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	conn, err := grpc.DialContext(ctx, controllerAddr,
+	conn, err := grpc.NewClient(controllerAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("connect to controller: %w", err)
+		return nil, fmt.Errorf("create grpc client: %w", err)
 	}
 
 	return &Client{


### PR DESCRIPTION
## Summary
- Remove `WithBlock()` from gRPC client so connection is established lazily on first RPC call
- Allows HTTP server to start before controller is ready, avoiding startup failures due to timing

## Test plan
- [ ] Deploy helm chart and verify HTTP pod starts even if controller isn't ready yet
- [ ] Verify gRPC calls work once controller comes up

🤖 Generated with [Claude Code](https://claude.com/claude-code)