### PR TITLE
fix: address Codex findings

### DIFF
--- a/internal/handlers/answer.go
+++ b/internal/handlers/answer.go
@@ -44,7 +44,12 @@ func (h *AnswerHandler) ServeAnswer(w http.ResponseWriter, r *http.Request) {
 	content, err := h.ctrlClient.GetRenderedTemplate(ctx, hostname, filename)
 	if err != nil {
 		log.Printf("Error getting rendered template for %s/%s: %v", hostname, filename, err)
-		w.WriteHeader(http.StatusNotFound)
+		// Distinguish between "not found" (404) and server/transport errors (502)
+		if strings.Contains(err.Error(), "grpc call:") {
+			w.WriteHeader(http.StatusBadGateway)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Summary
Addresses high and medium findings from Codex review.

## Fixes

### High: Race condition between boot start and answer retrieval
`GetRenderedTemplate` only accepted `InProgress` deploys, but `MarkBootStarted` runs after the boot script response is sent. Installer fetching `/answer/...` immediately could see `Pending` and get 404.

**Fix:** Try `InProgress` first, then fall back to `Pending`.

### Medium: 404 masks server errors  
`ServeAnswer` returned 404 for all errors, including gRPC failures. This masks server errors as "not found".

**Fix:** Return 502 for gRPC transport errors, 404 only for "not found".

## Not addressed
- Medium: Tests don't exercise real handler - lower priority, existing tests still validate logic

## Test plan
- [ ] Installer fetching `/answer/` immediately after boot script works (no 404 race)
- [ ] Controller down returns 502, not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)