### PR TITLE
chore: bump Go version to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/isoboot/isoboot
 
-go 1.25.0
+go 1.25.6
 
 require (
 	google.golang.org/grpc v1.78.0


### PR DESCRIPTION
## Summary
- Update go.mod from 1.24.0 to 1.25.0
- Matches golang:1.25-alpine used in chart pod definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)