### PR TITLE
feat(config): add DiskImageRef and DiskImageName support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ import (
 type TargetConfig struct {
 	ISO          string `json:"iso" yaml:"iso"`
 	Firmware     string `json:"firmware,omitempty" yaml:"firmware,omitempty"`
-	DiskImageRef string `json:"diskImageRef,omitempty" yaml:"diskImageRef,omitempty"` // Reference to a DiskImage identifier for file paths (defaults to target name if unset)
+	DiskImageRef string `json:"diskImageRef,omitempty" yaml:"diskImageRef,omitempty"`
 }
 
 type Config struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -238,7 +238,7 @@ func TestDiskImageName(t *testing.T) {
 		},
 		{
 			name:       "falls back to target name for lone ..",
-			config:     TargetConfig{DiskImageRef: ".."}, // safePathSegment("..") returns "", triggering fallback
+			config:     TargetConfig{DiskImageRef: ".."}, // invalid, falls back to target name
 			targetName: "debian-13",
 			expected:   "debian-13",
 		},


### PR DESCRIPTION
## Summary
Add DiskImageRef field to TargetConfig for explicit DiskImage references.

## Changes
- Add `DiskImageRef` field to `TargetConfig` struct
- Add `DiskImageName()` method that returns `DiskImageRef` if set, otherwise falls back to target name

## Why
This allows multiple BootTargets to share the same DiskImage, reducing storage requirements when the same ISO is used for different boot configurations.

## Example
```yaml
# Two BootTargets sharing one DiskImage
targets:
  debian-minimal:
    diskImageRef: debian-13  # Uses debian-13 DiskImage
    template: minimal.ipxe
  debian-full:
    diskImageRef: debian-13  # Same DiskImage
    template: full.ipxe
```

## Test Plan
- [x] Existing config tests pass
- [x] DiskImageName() returns correct value

🤖 Generated with [Claude Code](https://claude.com/claude-code)