### PR TITLE
fix: rename TemplateData.Target to BootTarget

### DIFF
--- a/internal/handlers/boot.go
+++ b/internal/handlers/boot.go
@@ -30,10 +30,10 @@ func NewBootHandler(host, port string, ctrlClient *controllerclient.Client, conf
 
 // TemplateData is passed to boot templates
 type TemplateData struct {
-	Host     string
-	Port     string
-	Hostname string
-	Target   string
+	Host       string
+	Port       string
+	Hostname   string
+	BootTarget string
 }
 
 func (h *BootHandler) loadTemplate(ctx context.Context, name string) (*template.Template, error) {
@@ -122,10 +122,10 @@ func (h *BootHandler) ServeConditionalBoot(w http.ResponseWriter, r *http.Reques
 	}
 
 	data := TemplateData{
-		Host:     h.host,
-		Port:     h.port,
-		Hostname: bootInfo.MachineName,
-		Target:   bootInfo.Target,
+		Host:       h.host,
+		Port:       h.port,
+		Hostname:   bootInfo.MachineName,
+		BootTarget: bootInfo.Target,
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
The BootTarget templates use `{{ .BootTarget }}` but the `TemplateData` struct field was named `Target`, causing template execution to fail with 500 error.

## Changes
- Rename `TemplateData.Target` to `TemplateData.BootTarget`
- Update the struct initialization to use `BootTarget:`

## Test plan
- [x] Unit tests pass
- [ ] Manual test with PXE boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)