### PR TITLE
feat: add /boot/done endpoint, remove /api/deploy/

### DIFF
--- a/internal/handlers/CLAUDE.md
+++ b/internal/handlers/CLAUDE.md
@@ -7,6 +7,7 @@ HTTP handlers for isoboot-http server.
 ### BootHandler (boot.go)
 - `GET /boot/boot.ipxe` - Initial iPXE script (chains to conditional-boot)
 - `GET /boot/conditional-boot?mac=xx-xx-xx-xx-xx-xx` - Returns BootTarget template if Deploy exists, 404 otherwise
+- `GET /boot/done?id={machineName}` - Marks Deploy as completed (call from preseed late_command)
 
 Template variables: Host, Port, MachineName, Hostname, Domain, BootTarget
 
@@ -16,7 +17,6 @@ Template variables: Host, Port, MachineName, Hostname, Domain, BootTarget
 
 ### AnswerHandler (answer.go)
 - `GET /answer/{machineName}/{filename}` - Serves rendered ResponseTemplate files
-- `POST /api/deploy/{machineName}/complete` - Marks Deploy as completed
 
 ## Error Handling
 

--- a/internal/handlers/answer.go
+++ b/internal/handlers/answer.go
@@ -59,39 +59,7 @@ func (h *AnswerHandler) ServeAnswer(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(content))
 }
 
-// CompleteDeployment marks a deployment as completed
-func (h *AnswerHandler) CompleteDeployment(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		return
-	}
-
-	// Parse path: /api/deploy/{hostname}/complete
-	path := strings.TrimPrefix(r.URL.Path, "/api/deploy/")
-	parts := strings.Split(path, "/")
-	if len(parts) < 2 || parts[1] != "complete" {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	hostname := parts[0]
-	ctx := r.Context()
-
-	// Mark deploy as completed via controller (using hostname)
-	if err := h.ctrlClient.MarkBootCompleted(ctx, hostname); err != nil {
-		log.Printf("Error completing deploy for %s: %v", hostname, err)
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
-	body := []byte("OK")
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
-	w.WriteHeader(http.StatusOK)
-	w.Write(body)
-}
-
 // RegisterRoutes registers answer file routes
 func (h *AnswerHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/answer/", h.ServeAnswer)
-	mux.HandleFunc("/api/deploy/", h.CompleteDeployment)
 }


### PR DESCRIPTION
## Summary
- Add `GET /boot/done?id={machineName}` for completion callbacks
- Remove `POST /api/deploy/{hostname}/complete` (replaced by /boot/done)

## Completion Callback
Preseed can call back when installation completes:
```
d-i preseed/late_command string wget -qO- http://{{ .Host }}:{{ .Port }}/boot/done?id={{ .Hostname }} || true
```

## Test plan
- [x] Tests pass
- [x] Manual test: completion callback marks Deploy as Complete

🤖 Generated with [Claude Code](https://claude.ai/code)