### PR TITLE
fix: use readable file permissions for downloaded ISOs

### DIFF
--- a/internal/controller/diskimage.go
+++ b/internal/controller/diskimage.go
@@ -257,8 +257,8 @@ func (c *Controller) downloadAndVerify(ctx context.Context, fileURL, destPath st
 		DigestSha512:  "pending",
 	}
 
-	// Create parent directory with restricted permissions
-	if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
+	// Create parent directory with readable permissions for HTTP server
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 		result.FileSizeMatch = "failed"
 		return result, fmt.Errorf("create directory: %w", err)
 	}
@@ -319,9 +319,9 @@ func (c *Controller) downloadAndVerify(ctx context.Context, fileURL, destPath st
 		return result, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 
-	// Create temp file with restricted permissions
+	// Create temp file with readable permissions for HTTP server
 	tmpPath := destPath + ".tmp"
-	tmpFile, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	tmpFile, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		result.FileSizeMatch = "failed"
 		return result, fmt.Errorf("create temp file: %w", err)


### PR DESCRIPTION
## Summary
- Change directory permissions from `0700` to `0755`
- Change file permissions from `0600` to `0644`

## Problem
Downloaded ISO files had restrictive permissions (700/600), causing the HTTP server to get 404 errors when trying to serve them.

The controller and HTTP server share a hostPath volume but run as different pods, so files need to be world-readable.

## Test plan
- [ ] Delete existing DiskImage and let it re-download
- [ ] Verify new files have 755/644 permissions
- [ ] Verify HTTP server can serve ISO content

🤖 Generated with [Claude Code](https://claude.com/claude-code)