### PR TITLE
feat: derive SSH public keys from private keys in secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,11 +29,12 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	golang.org/x/net v0.47.0 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
+	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
-	golang.org/x/term v0.37.0 // indirect
-	golang.org/x/text v0.31.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/term v0.39.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42s
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -99,6 +101,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
+golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
+golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
 golang.org/x/oauth2 v0.32.0 h1:jsCblLleRMDrxMN29H3z/k1KliIvpLgCkE6R8FXXNgY=
 golang.org/x/oauth2 v0.32.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -109,12 +113,18 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
 golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
+golang.org/x/term v0.39.0 h1:RclSuaJf32jOqZz74CkPA9qFuVTX7vhLlpfj/IGWlqY=
+golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
 golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
+golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=
+golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=
 golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -123,6 +133,7 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
+golang.org/x/tools v0.40.0 h1:yLkxfA+Qnul4cs9QA3KnlFu0lVmd8JJfoq+E41uSutA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -241,6 +241,11 @@ func (c *Controller) RenderTemplate(ctx context.Context, provision *k8s.Provisio
 		}
 	}
 
+	// Derive SSH public keys from private keys in secrets
+	if err := DeriveSSHPublicKeys(data); err != nil {
+		return "", fmt.Errorf("derive SSH public keys: %w", err)
+	}
+
 	// Add system variables
 	data["Host"] = c.host
 	data["Port"] = c.port

--- a/internal/controller/sshkeys.go
+++ b/internal/controller/sshkeys.go
@@ -1,0 +1,80 @@
+package controller
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// sshHostKeyPrefixes are the key names we look for in secrets
+var sshHostKeyPrefixes = []string{
+	"ssh_host_rsa_key",
+	"ssh_host_ecdsa_key",
+	"ssh_host_ed25519_key",
+}
+
+// DeriveSSHPublicKeys looks for SSH host private keys in the data map and
+// derives their public keys. For each key like "ssh_host_ed25519_key", it adds
+// "ssh_host_ed25519_key_pub" with the OpenSSH-formatted public key.
+func DeriveSSHPublicKeys(data map[string]interface{}) error {
+	for _, keyName := range sshHostKeyPrefixes {
+		privateKeyPEM, ok := data[keyName]
+		if !ok {
+			continue
+		}
+
+		privateKeyStr, ok := privateKeyPEM.(string)
+		if !ok {
+			continue
+		}
+
+		// Skip empty keys
+		if strings.TrimSpace(privateKeyStr) == "" {
+			continue
+		}
+
+		pubKey, err := derivePublicKey(privateKeyStr)
+		if err != nil {
+			return fmt.Errorf("failed to derive public key for %s: %w", keyName, err)
+		}
+
+		data[keyName+"_pub"] = pubKey
+	}
+
+	return nil
+}
+
+// derivePublicKey parses an OpenSSH private key and returns the public key
+// in OpenSSH authorized_keys format (e.g., "ssh-ed25519 AAAA...")
+func derivePublicKey(privateKeyPEM string) (string, error) {
+	// Parse the private key
+	privateKey, err := ssh.ParseRawPrivateKey([]byte(privateKeyPEM))
+	if err != nil {
+		return "", fmt.Errorf("parse private key: %w", err)
+	}
+
+	// Extract the public key based on key type
+	var pubKey ssh.PublicKey
+
+	switch key := privateKey.(type) {
+	case *rsa.PrivateKey:
+		pubKey, err = ssh.NewPublicKey(&key.PublicKey)
+	case *ecdsa.PrivateKey:
+		pubKey, err = ssh.NewPublicKey(&key.PublicKey)
+	case *ed25519.PrivateKey:
+		pubKey, err = ssh.NewPublicKey(key.Public())
+	default:
+		return "", fmt.Errorf("unsupported key type: %T", privateKey)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("create public key: %w", err)
+	}
+
+	// Format as OpenSSH public key (type + base64 data)
+	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pubKey))), nil
+}

--- a/internal/controller/sshkeys_test.go
+++ b/internal/controller/sshkeys_test.go
@@ -1,0 +1,124 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+)
+
+// Test ED25519 key pair (generated for testing with ssh-keygen)
+const testED25519PrivateKey = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACB+ajyqUbLe98zqQ86LWl5dFkBCtEVkSZXiFogJJ1eGfQAAAJjUjRwy1I0c
+MgAAAAtzc2gtZWQyNTUxOQAAACB+ajyqUbLe98zqQ86LWl5dFkBCtEVkSZXiFogJJ1eGfQ
+AAAEBTCGvVNZAxqiWIr5dnF+AkyPsi8FauWqNAV33OTroHOH5qPKpRst73zOpDzotaXl0W
+QEK0RWRJleIWiAknV4Z9AAAAEHRlc3RAZXhhbXBsZS5jb20BAgMEBQ==
+-----END OPENSSH PRIVATE KEY-----`
+
+const testED25519PublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH5qPKpRst73zOpDzotaXl0WQEK0RWRJleIWiAknV4Z9"
+
+func TestDeriveSSHPublicKeys_ED25519(t *testing.T) {
+	data := map[string]interface{}{
+		"ssh_host_ed25519_key": testED25519PrivateKey,
+	}
+
+	err := DeriveSSHPublicKeys(data)
+	if err != nil {
+		t.Fatalf("DeriveSSHPublicKeys failed: %v", err)
+	}
+
+	pubKey, ok := data["ssh_host_ed25519_key_pub"]
+	if !ok {
+		t.Fatal("expected ssh_host_ed25519_key_pub to be set")
+	}
+
+	pubKeyStr, ok := pubKey.(string)
+	if !ok {
+		t.Fatal("expected ssh_host_ed25519_key_pub to be a string")
+	}
+
+	if pubKeyStr != testED25519PublicKey {
+		t.Errorf("public key mismatch:\ngot:  %s\nwant: %s", pubKeyStr, testED25519PublicKey)
+	}
+}
+
+func TestDeriveSSHPublicKeys_EmptyKey(t *testing.T) {
+	data := map[string]interface{}{
+		"ssh_host_ed25519_key": "",
+	}
+
+	err := DeriveSSHPublicKeys(data)
+	if err != nil {
+		t.Fatalf("DeriveSSHPublicKeys failed: %v", err)
+	}
+
+	// Should not add _pub key for empty private key
+	if _, ok := data["ssh_host_ed25519_key_pub"]; ok {
+		t.Error("expected ssh_host_ed25519_key_pub to NOT be set for empty key")
+	}
+}
+
+func TestDeriveSSHPublicKeys_NoKeys(t *testing.T) {
+	data := map[string]interface{}{
+		"some_other_key": "some_value",
+	}
+
+	err := DeriveSSHPublicKeys(data)
+	if err != nil {
+		t.Fatalf("DeriveSSHPublicKeys failed: %v", err)
+	}
+
+	// Should not add any _pub keys
+	for key := range data {
+		if strings.HasSuffix(key, "_pub") {
+			t.Errorf("unexpected _pub key: %s", key)
+		}
+	}
+}
+
+func TestDeriveSSHPublicKeys_MultipleKeys(t *testing.T) {
+	data := map[string]interface{}{
+		"ssh_host_ed25519_key": testED25519PrivateKey,
+		"some_config":          "value",
+	}
+
+	err := DeriveSSHPublicKeys(data)
+	if err != nil {
+		t.Fatalf("DeriveSSHPublicKeys failed: %v", err)
+	}
+
+	// Check ED25519 pub key exists
+	if _, ok := data["ssh_host_ed25519_key_pub"]; !ok {
+		t.Error("expected ssh_host_ed25519_key_pub to be set")
+	}
+
+	// Check original data preserved
+	if data["some_config"] != "value" {
+		t.Error("expected some_config to be preserved")
+	}
+}
+
+func TestDeriveSSHPublicKeys_InvalidKey(t *testing.T) {
+	data := map[string]interface{}{
+		"ssh_host_ed25519_key": "not a valid key",
+	}
+
+	err := DeriveSSHPublicKeys(data)
+	if err == nil {
+		t.Fatal("expected error for invalid key")
+	}
+
+	if !strings.Contains(err.Error(), "ssh_host_ed25519_key") {
+		t.Errorf("error should mention key name: %v", err)
+	}
+}
+
+func TestDerivePublicKey_ED25519(t *testing.T) {
+	pubKey, err := derivePublicKey(testED25519PrivateKey)
+	if err != nil {
+		t.Fatalf("derivePublicKey failed: %v", err)
+	}
+
+	if !strings.HasPrefix(pubKey, "ssh-ed25519 ") {
+		t.Errorf("expected ssh-ed25519 prefix, got: %s", pubKey)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `DeriveSSHPublicKeys()` function to automatically derive public keys from SSH private keys stored in secrets
- Supports RSA, ECDSA, and ED25519 key types
- When secrets contain `ssh_host_*_key` entries, corresponding `*_pub` entries are added to template data
- Enables ResponseTemplates to use `{{ if .ssh_host_ed25519_key }}` conditionals

## Use Case
Avoid SSH known_hosts warnings after reinstall by injecting consistent host keys via preseed/late_command.

## Test plan
- [x] Unit tests for `DeriveSSHPublicKeys()` and `derivePublicKey()`
- [x] Test empty keys are skipped
- [x] Test invalid keys return errors
- [x] `go test ./...` passes
- [x] Builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)