### PR TITLE
fix: require lowercase hex for machineId

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -14,8 +14,8 @@ import (
 	"github.com/isoboot/isoboot/internal/k8s"
 )
 
-// validMachineId validates systemd machine-id format (exactly 32 hex characters)
-var validMachineId = regexp.MustCompile(`^[0-9a-fA-F]{32}$`)
+// validMachineId validates systemd machine-id format (exactly 32 lowercase hex characters)
+var validMachineId = regexp.MustCompile(`^[0-9a-f]{32}$`)
 
 // templateFuncs provides custom functions for templates
 var templateFuncs = template.FuncMap{

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -268,8 +268,8 @@ func TestValidMachineId(t *testing.T) {
 		valid bool
 	}{
 		{"valid 32 hex lowercase", "0123456789abcdef0123456789abcdef", true},
-		{"valid 32 hex uppercase", "0123456789ABCDEF0123456789ABCDEF", true},
-		{"valid 32 hex mixed case", "0123456789AbCdEf0123456789aBcDeF", true},
+		{"uppercase rejected", "0123456789ABCDEF0123456789ABCDEF", false},
+		{"mixed case rejected", "0123456789AbCdEf0123456789aBcDeF", false},
 		{"too short 31 chars", "0123456789abcdef0123456789abcde", false},
 		{"too long 33 chars", "0123456789abcdef0123456789abcdef0", false},
 		{"contains non-hex g", "0123456789abcdefg123456789abcdef", false},


### PR DESCRIPTION
## Summary
Require lowercase hex only for machineId to match systemd machine-id convention.

## Changes
- Pattern: `^[0-9a-f]{32}$` (was `^[0-9a-fA-F]{32}$`)
- Tests updated to reject uppercase/mixed case

🤖 Generated with [Claude Code](https://claude.com/claude-code)