### PR TITLE
feat: add machineId support to Provision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Available variables in ResponseTemplate (preseed/answer files):
 - `.Port` - HTTP server port
 - `.Hostname` - machine reference from Provision
 - `.Target` - boot target reference from Provision
-- `.MachineId` - systemd machine-id from Machine (use `hasKey` to check if set)
+- `.MachineId` - systemd machine-id from Provision (or Machine as fallback, use `hasKey` to check if set)
 - `.key` - values merged from referenced ConfigMaps and Secrets (flat namespace)
 - `.ssh_host_*_key_pub` - auto-derived public keys for SSH host keys in secrets
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -64,6 +64,7 @@ type ProvisionSpec struct {
 	ResponseTemplateRef string
 	ConfigMaps          []string
 	Secrets             []string
+	MachineId           string // Optional systemd machine-id (32 lowercase hex chars)
 }
 
 type ProvisionStatus struct {
@@ -345,6 +346,7 @@ func parseProvision(obj *unstructured.Unstructured) (*Provision, error) {
 			ResponseTemplateRef: getString(spec, "responseTemplateRef"),
 			ConfigMaps:          getStringSlice(spec, "configMaps"),
 			Secrets:             getStringSlice(spec, "secrets"),
+			MachineId:           getString(spec, "machineId"),
 		},
 	}
 


### PR DESCRIPTION
## Summary
Add `machineId` field to `ProvisionSpec`, enabling per-installation machine IDs. This is backwards compatible - `Machine.machineId` is still supported as a fallback.

## Changes
- Add `MachineId` to `ProvisionSpec` struct
- Update `parseProvision()` to extract machineId
- Validate machineId format on Provision in `validateProvisionRefs()`
- Prefer `Provision.MachineId` in `RenderTemplate()`, fall back to `Machine.MachineId`
- Update CLAUDE.md to document the preference order

## Addresses Copilot Comments
- Error messages now specify "lowercase hex characters" to match actual validation

## Related
- Companion PR: https://github.com/isoboot/isoboot-chart/pull/49

## Test plan
- [x] `go test ./...` passes
- [ ] Deploy with updated chart
- [ ] Create Provision with machineId, verify template renders correctly
- [ ] Create Provision without machineId, verify Machine.machineId fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)