### PR TITLE
feat: remove machineId from Machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Available variables in ResponseTemplate (preseed/answer files):
 - `.Port` - HTTP server port
 - `.Hostname` - machine reference from Provision
 - `.Target` - boot target reference from Provision
-- `.MachineId` - systemd machine-id from Machine (use `hasKey` to check if set)
+- `.MachineId` - systemd machine-id from Provision (use `hasKey` to check if set)
 - `.key` - values merged from referenced ConfigMaps and Secrets (flat namespace)
 - `.ssh_host_*_key_pub` - auto-derived public keys for SSH host keys in secrets
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -196,15 +196,9 @@ func checkDiskImageStatus(diskImage *k8s.DiskImage) (bool, string) {
 
 // validateProvisionRefs checks that all referenced resources exist and have valid configuration
 func (c *Controller) validateProvisionRefs(ctx context.Context, provision *k8s.Provision) error {
-	// Validate machineRef and its configuration
-	machine, err := c.k8sClient.GetMachine(ctx, provision.Spec.MachineRef)
-	if err != nil {
+	// Validate machineRef exists
+	if _, err := c.k8sClient.GetMachine(ctx, provision.Spec.MachineRef); err != nil {
 		return fmt.Errorf("Machine '%s' not found", provision.Spec.MachineRef)
-	}
-
-	// Validate machineId format if present
-	if machine.MachineId != "" && !validMachineId.MatchString(machine.MachineId) {
-		return fmt.Errorf("Machine '%s' has invalid machineId: must be exactly 32 hex characters", provision.Spec.MachineRef)
 	}
 
 	// Validate bootTargetRef (BootTarget)
@@ -273,14 +267,6 @@ func (c *Controller) RenderTemplate(ctx context.Context, provision *k8s.Provisio
 	data["Port"] = c.port
 	data["Hostname"] = provision.Spec.MachineRef
 	data["Target"] = provision.Spec.BootTargetRef
-
-	// Add MachineId from Machine if set (use hasKey in templates to check)
-	if c.k8sClient != nil {
-		machine, err := c.k8sClient.GetMachine(ctx, provision.Spec.MachineRef)
-		if err == nil && machine.MachineId != "" {
-			data["MachineId"] = machine.MachineId
-		}
-	}
 
 	// Parse and execute template
 	tmpl, err := template.New("response").Funcs(templateFuncs).Option("missingkey=error").Parse(templateContent)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -46,9 +46,8 @@ var (
 
 // Machine represents a Machine CRD
 type Machine struct {
-	Name      string
-	MAC       string
-	MachineId string // Optional systemd machine-id (32 hex chars)
+	Name string
+	MAC  string
 }
 
 // Provision represents a Provision CRD
@@ -187,9 +186,8 @@ func parseMachine(obj *unstructured.Unstructured) (*Machine, error) {
 	}
 
 	return &Machine{
-		Name:      obj.GetName(),
-		MAC:       strings.ToLower(mac),
-		MachineId: getString(spec, "machineId"),
+		Name: obj.GetName(),
+		MAC:  strings.ToLower(mac),
 	}, nil
 }
 

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -475,37 +475,18 @@ func TestParseMachine(t *testing.T) {
 		expectError bool
 	}{
 		{
-			name: "valid Machine with machineId",
+			name: "valid Machine",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{"name": "vm-01.lan"},
 					"spec": map[string]interface{}{
-						"mac":       "AA-BB-CC-DD-EE-FF",
-						"machineId": "0123456789abcdef0123456789abcdef",
+						"mac": "AA-BB-CC-DD-EE-FF",
 					},
 				},
 			},
 			expected: &Machine{
-				Name:      "vm-01.lan",
-				MAC:       "aa-bb-cc-dd-ee-ff", // lowercase
-				MachineId: "0123456789abcdef0123456789abcdef",
-			},
-			expectError: false,
-		},
-		{
-			name: "valid Machine without machineId",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{"name": "vm-02.lan"},
-					"spec": map[string]interface{}{
-						"mac": "11-22-33-44-55-66",
-					},
-				},
-			},
-			expected: &Machine{
-				Name:      "vm-02.lan",
-				MAC:       "11-22-33-44-55-66",
-				MachineId: "",
+				Name: "vm-01.lan",
+				MAC:  "aa-bb-cc-dd-ee-ff", // lowercase
 			},
 			expectError: false,
 		},
@@ -549,9 +530,6 @@ func TestParseMachine(t *testing.T) {
 			}
 			if result.MAC != tt.expected.MAC {
 				t.Errorf("MAC = %q, want %q", result.MAC, tt.expected.MAC)
-			}
-			if result.MachineId != tt.expected.MachineId {
-				t.Errorf("MachineId = %q, want %q", result.MachineId, tt.expected.MachineId)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Remove `machineId` from Machine as it belongs on Provision (per-installation, not per-hardware).

## Changes
- Remove `MachineId` from `Machine` struct
- Remove machineId parsing from `parseMachine()`
- Remove Machine machineId validation from controller
- Remove Machine machineId fallback from `RenderTemplate()`
- Update CLAUDE.md to reflect MachineId comes from Provision
- Update tests

## Breaking Change
`Machine.machineId` has been removed. Users should migrate to using `Provision.machineId` instead.

## Addresses Copilot Comments
- CLAUDE.md now correctly states MachineId comes from Provision, not Machine

## Related
- Prerequisite: #38 (adds machineId support to Provision)
- Companion PR: https://github.com/isoboot/isoboot-chart/pull/51

## Test plan
- [x] `go test ./...` passes
- [ ] Deploy with updated chart
- [ ] Verify Provision.machineId works for template rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)