### PR TITLE
feat: remove machineId from Machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Available variables in ResponseTemplate (preseed/answer files):
 - `.Port` - HTTP server port
 - `.Hostname` - machine reference from Provision
 - `.Target` - boot target reference from Provision
-- `.MachineId` - systemd machine-id from Provision (or Machine as fallback, use `hasKey` to check if set)
+- `.MachineId` - systemd machine-id from Provision (use `hasKey` to check if set)
 - `.key` - values merged from referenced ConfigMaps and Secrets (flat namespace)
 - `.ssh_host_*_key_pub` - auto-derived public keys for SSH host keys in secrets
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -196,18 +196,12 @@ func checkDiskImageStatus(diskImage *k8s.DiskImage) (bool, string) {
 
 // validateProvisionRefs checks that all referenced resources exist and have valid configuration
 func (c *Controller) validateProvisionRefs(ctx context.Context, provision *k8s.Provision) error {
-	// Validate machineRef and its configuration
-	machine, err := c.k8sClient.GetMachine(ctx, provision.Spec.MachineRef)
-	if err != nil {
+	// Validate machineRef exists
+	if _, err := c.k8sClient.GetMachine(ctx, provision.Spec.MachineRef); err != nil {
 		return fmt.Errorf("Machine '%s' not found", provision.Spec.MachineRef)
 	}
 
-	// Validate machineId format if present (on Machine - legacy)
-	if machine.MachineId != "" && !validMachineId.MatchString(machine.MachineId) {
-		return fmt.Errorf("Machine '%s' has invalid machineId: must be exactly 32 lowercase hex characters", provision.Spec.MachineRef)
-	}
-
-	// Validate machineId format if present (on Provision - preferred)
+	// Validate machineId format if present
 	if provision.Spec.MachineId != "" && !validMachineId.MatchString(provision.Spec.MachineId) {
 		return fmt.Errorf("Provision '%s' has invalid machineId: must be exactly 32 lowercase hex characters", provision.Name)
 	}
@@ -279,14 +273,9 @@ func (c *Controller) RenderTemplate(ctx context.Context, provision *k8s.Provisio
 	data["Hostname"] = provision.Spec.MachineRef
 	data["Target"] = provision.Spec.BootTargetRef
 
-	// Add MachineId - prefer Provision, fallback to Machine (use hasKey in templates to check)
+	// Add MachineId from Provision if set (use hasKey in templates to check)
 	if provision.Spec.MachineId != "" {
 		data["MachineId"] = provision.Spec.MachineId
-	} else if c.k8sClient != nil {
-		machine, err := c.k8sClient.GetMachine(ctx, provision.Spec.MachineRef)
-		if err == nil && machine.MachineId != "" {
-			data["MachineId"] = machine.MachineId
-		}
 	}
 
 	// Parse and execute template

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -46,9 +46,8 @@ var (
 
 // Machine represents a Machine CRD
 type Machine struct {
-	Name      string
-	MAC       string
-	MachineId string // Optional systemd machine-id (32 hex chars)
+	Name string
+	MAC  string
 }
 
 // Provision represents a Provision CRD
@@ -188,9 +187,8 @@ func parseMachine(obj *unstructured.Unstructured) (*Machine, error) {
 	}
 
 	return &Machine{
-		Name:      obj.GetName(),
-		MAC:       strings.ToLower(mac),
-		MachineId: getString(spec, "machineId"),
+		Name: obj.GetName(),
+		MAC:  strings.ToLower(mac),
 	}, nil
 }
 

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -486,14 +486,13 @@ func TestParseMachine(t *testing.T) {
 				},
 			},
 			expected: &Machine{
-				Name:      "vm-01.lan",
-				MAC:       "aa-bb-cc-dd-ee-ff", // lowercase
-				MachineId: "0123456789abcdef0123456789abcdef",
+				Name: "vm-01.lan",
+				MAC:  "aa-bb-cc-dd-ee-ff", // lowercase
 			},
 			expectError: false,
 		},
 		{
-			name: "valid Machine without machineId",
+			name: "valid Machine simple",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{"name": "vm-02.lan"},
@@ -503,9 +502,8 @@ func TestParseMachine(t *testing.T) {
 				},
 			},
 			expected: &Machine{
-				Name:      "vm-02.lan",
-				MAC:       "11-22-33-44-55-66",
-				MachineId: "",
+				Name: "vm-02.lan",
+				MAC:  "11-22-33-44-55-66",
 			},
 			expectError: false,
 		},
@@ -549,9 +547,6 @@ func TestParseMachine(t *testing.T) {
 			}
 			if result.MAC != tt.expected.MAC {
 				t.Errorf("MAC = %q, want %q", result.MAC, tt.expected.MAC)
-			}
-			if result.MachineId != tt.expected.MachineId {
-				t.Errorf("MachineId = %q, want %q", result.MachineId, tt.expected.MachineId)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Remove machineId from Machine - it now lives only on Provision (per-installation, not per-hardware).

## Changes
- Remove MachineId field from Machine struct
- Remove Machine.MachineId validation from controller
- Remove Machine fallback in template rendering
- Update tests and documentation

## Related
- Depends on: #38 (add machineId to Provision)
- Chart companion: isoboot-chart#51

## Test plan
- [x] `go test ./...` passes
- [ ] Deploy and verify machineId works from Provision only

🤖 Generated with [Claude Code](https://claude.com/claude-code)