### PR TITLE
feat: add ProxyPort to boot template data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-# Compiled binaries
-isoboot-controller
-isoboot-http
+# Compiled binaries (root directory only)
+/isoboot-controller
+/isoboot-http

--- a/cmd/isoboot-http/main.go
+++ b/cmd/isoboot-http/main.go
@@ -77,7 +77,7 @@ func main() {
 	})
 
 	// Boot handlers
-	bootHandler := handlers.NewBootHandler(host, port, ctrlClient, templatesConfigMap)
+	bootHandler := handlers.NewBootHandler(host, port, proxyPort, ctrlClient, templatesConfigMap)
 	bootHandler.RegisterRoutes(mux)
 
 	// ISO content handlers

--- a/internal/handlers/boot.go
+++ b/internal/handlers/boot.go
@@ -16,14 +16,16 @@ import (
 type BootHandler struct {
 	host       string
 	port       string
+	proxyPort  string
 	ctrlClient *controllerclient.Client
 	configMap  string
 }
 
-func NewBootHandler(host, port string, ctrlClient *controllerclient.Client, configMap string) *BootHandler {
+func NewBootHandler(host, port, proxyPort string, ctrlClient *controllerclient.Client, configMap string) *BootHandler {
 	return &BootHandler{
 		host:       host,
 		port:       port,
+		proxyPort:  proxyPort,
 		ctrlClient: ctrlClient,
 		configMap:  configMap,
 	}
@@ -33,6 +35,7 @@ func NewBootHandler(host, port string, ctrlClient *controllerclient.Client, conf
 type TemplateData struct {
 	Host          string
 	Port          string
+	ProxyPort     string // Squid proxy port for mirror/http/proxy
 	MachineName   string // Full machine name (e.g., "vm-deb-0099.lan")
 	Hostname      string // First part before dot (e.g., "vm-deb-0099")
 	Domain        string // Everything after first dot (e.g., "lan")
@@ -71,8 +74,9 @@ func (h *BootHandler) ServeBootIPXE(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := TemplateData{
-		Host: h.host,
-		Port: h.port,
+		Host:      h.host,
+		Port:      h.port,
+		ProxyPort: h.proxyPort,
 	}
 
 	var buf bytes.Buffer
@@ -170,6 +174,7 @@ func (h *BootHandler) ServeConditionalBoot(w http.ResponseWriter, r *http.Reques
 	data := TemplateData{
 		Host:          h.host,
 		Port:          h.port,
+		ProxyPort:     h.proxyPort,
 		MachineName:   machineName,
 		Hostname:      hostname,
 		Domain:        domain,


### PR DESCRIPTION
## Summary

- Add `ProxyPort` field to `TemplateData` struct
- Wire `--proxy-port` from isoboot-http to `BootHandler`
- Boot templates can now use `{{ .ProxyPort }}` instead of hard-coding 3128

## Problem

Boot template hard-codes proxy port to 3128. If users change `values.proxy.port`, booted installers still point at 3128 and fail to fetch packages.

## Fix

Pass the proxy port through the template data so templates can use `{{ .ProxyPort }}`.

## Also

Fixed `.gitignore` to only match binaries at root (was blocking `cmd/isoboot-http/` dir).

## Test plan

- [ ] `go test ./...`
- [ ] Build and verify `--proxy-port` is passed to boot templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)