### PR TITLE
Add pathTraversalMiddleware to isoboot-http

### DIFF
--- a/cmd/isoboot-http/main.go
+++ b/cmd/isoboot-http/main.go
@@ -113,7 +113,11 @@ func main() {
 	log.Printf("ISO path: %s", isoPath)
 	log.Printf("Templates ConfigMap: %s", templatesConfigMap)
 
-	if err := http.ListenAndServe(addr, loggingMiddleware(pathTraversalMiddleware(mux))); err != nil {
+	var handler http.Handler = mux
+	handler = pathTraversalMiddleware(handler)
+	handler = loggingMiddleware(handler)
+
+	if err := http.ListenAndServe(addr, handler); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }

--- a/cmd/isoboot-http/main.go
+++ b/cmd/isoboot-http/main.go
@@ -33,6 +33,7 @@ func pathTraversalMiddleware(next http.Handler) http.Handler {
 		// Reject if any path segment is ".."
 		for _, segment := range strings.Split(normalizedPath, "/") {
 			if segment == ".." {
+				log.Printf("blocked path traversal: path=%q remote_addr=%s", r.URL.Path, r.RemoteAddr)
 				http.Error(w, "invalid path", http.StatusBadRequest)
 				return
 			}

--- a/cmd/isoboot-http/main_test.go
+++ b/cmd/isoboot-http/main_test.go
@@ -97,6 +97,41 @@ func TestLoggingMiddleware_CapturesStatusCode(t *testing.T) {
 	}
 }
 
+func TestPathTraversalMiddleware_BlocksTraversal(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := pathTraversalMiddleware(handler)
+
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{"normal path", "/iso/content/foo/bar", http.StatusOK},
+		{"root path", "/", http.StatusOK},
+		{"healthz", "/healthz", http.StatusOK},
+		{"dotdot segment", "/iso/content/../etc/passwd", http.StatusBadRequest},
+		{"dotdot at start", "/../etc/passwd", http.StatusBadRequest},
+		{"dotdot at end", "/foo/bar/..", http.StatusBadRequest},
+		{"bare dotdot", "/..", http.StatusBadRequest},
+		{"backslash traversal", "/iso/content\\..\\etc\\passwd", http.StatusBadRequest},
+		{"single dot is fine", "/foo/./bar", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			rec := httptest.NewRecorder()
+			wrapped.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("path %q: got status %d, want %d", tt.path, rec.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
 func TestLoggingMiddleware_DefaultStatusOK(t *testing.T) {
 	// Handler that writes body but doesn't call WriteHeader
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/isoboot-http/main_test.go
+++ b/cmd/isoboot-http/main_test.go
@@ -117,6 +117,10 @@ func TestPathTraversalMiddleware_BlocksTraversal(t *testing.T) {
 		{"bare dotdot", "/..", http.StatusBadRequest},
 		{"backslash traversal", "/iso/content\\..\\etc\\passwd", http.StatusBadRequest},
 		{"single dot is fine", "/foo/./bar", http.StatusOK},
+		// URL-encoded variants: Go decodes %2e to "." before r.URL.Path,
+		// so these are caught by the same segment check.
+		{"url-encoded dotdot", "/foo/%2e%2e/bar", http.StatusBadRequest},
+		{"url-encoded mixed case", "/foo/%2E%2E/bar", http.StatusBadRequest},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add HTTP middleware that rejects requests with `..` path segments before they reach handlers
- Normalizes backslashes to forward slashes for defense against mixed-separator traversal
- Wraps the mux as `loggingMiddleware(pathTraversalMiddleware(mux))`
- Add tests covering normal paths, traversal attempts, and backslash variants

Defense-in-depth — handlers still perform their own containment validation.

Closes #68

## Test plan

- [x] `go test ./...` passes
- [ ] Verify `curl http://host:8080/iso/content/../etc/passwd` returns 400
- [ ] Verify normal paths like `/healthz` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)