### PR TITLE
Define handler interfaces for controller client dependency

### DIFF
--- a/internal/handlers/answer.go
+++ b/internal/handlers/answer.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -9,14 +10,23 @@ import (
 	"github.com/isoboot/isoboot/internal/controllerclient"
 )
 
+// AnswerClient defines the controller operations needed by AnswerHandler.
+type AnswerClient interface {
+	GetProvision(ctx context.Context, name string) (*controllerclient.ProvisionInfo, error)
+	GetResponseTemplate(ctx context.Context, name string) (*controllerclient.ResponseTemplateInfo, error)
+	GetConfigMaps(ctx context.Context, names []string) (map[string]string, error)
+	GetSecrets(ctx context.Context, names []string) (map[string]string, error)
+	GetMachine(ctx context.Context, name string) (string, error)
+}
+
 type AnswerHandler struct {
 	host       string
 	port       string
 	proxyPort  string
-	ctrlClient *controllerclient.Client
+	ctrlClient AnswerClient
 }
 
-func NewAnswerHandler(host, port, proxyPort string, ctrlClient *controllerclient.Client) *AnswerHandler {
+func NewAnswerHandler(host, port, proxyPort string, ctrlClient AnswerClient) *AnswerHandler {
 	return &AnswerHandler{
 		host:       host,
 		port:       port,

--- a/internal/handlers/boot.go
+++ b/internal/handlers/boot.go
@@ -13,15 +13,24 @@ import (
 	"github.com/isoboot/isoboot/internal/controllerclient"
 )
 
+// BootClient defines the controller operations needed by BootHandler.
+type BootClient interface {
+	GetConfigMapValue(ctx context.Context, configMapName, key string) (string, error)
+	GetMachineByMAC(ctx context.Context, mac string) (string, error)
+	GetProvisionsByMachine(ctx context.Context, machineName string) ([]controllerclient.ProvisionSummary, error)
+	GetBootTarget(ctx context.Context, name string) (*controllerclient.BootTargetInfo, error)
+	UpdateProvisionStatus(ctx context.Context, name, status, message, ip string) error
+}
+
 type BootHandler struct {
 	host       string
 	port       string
 	proxyPort  string
-	ctrlClient *controllerclient.Client
+	ctrlClient BootClient
 	configMap  string
 }
 
-func NewBootHandler(host, port, proxyPort string, ctrlClient *controllerclient.Client, configMap string) *BootHandler {
+func NewBootHandler(host, port, proxyPort string, ctrlClient BootClient, configMap string) *BootHandler {
 	return &BootHandler{
 		host:       host,
 		port:       port,

--- a/internal/handlers/iso.go
+++ b/internal/handlers/iso.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -21,12 +22,17 @@ var validDiskImageRef = regexp.MustCompile(`^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$`
 
 const streamChunkSize = 1024 * 1024 // 1MB chunks for streaming
 
-type ISOHandler struct {
-	basePath         string
-	controllerClient *controllerclient.Client
+// ISOClient defines the controller operations needed by ISOHandler.
+type ISOClient interface {
+	GetBootTarget(ctx context.Context, name string) (*controllerclient.BootTargetInfo, error)
 }
 
-func NewISOHandler(basePath string, controllerClient *controllerclient.Client) *ISOHandler {
+type ISOHandler struct {
+	basePath         string
+	controllerClient ISOClient
+}
+
+func NewISOHandler(basePath string, controllerClient ISOClient) *ISOHandler {
 	return &ISOHandler{
 		basePath:         basePath,
 		controllerClient: controllerClient,


### PR DESCRIPTION
## Summary

- Add `BootClient` interface (5 methods) in `boot.go`
- Add `AnswerClient` interface (5 methods) in `answer.go`
- Add `ISOClient` interface (1 method) in `iso.go`
- Change handler struct fields from `*controllerclient.Client` to interface types
- `*controllerclient.Client` satisfies all three implicitly — zero changes to `main.go`

Part of #74. Closes #75.

## Test plan

- [x] `go build ./...` compiles (implicit interface satisfaction verified)
- [x] `go test ./...` passes (all existing tests still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)