### PR TITLE
Define KubernetesClient interface for controller

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -21,14 +21,14 @@ const (
 
 // Controller watches Provision CRDs and manages their lifecycle
 type Controller struct {
-	k8sClient                *k8s.Client
+	k8sClient                KubernetesClient
 	stopCh                   chan struct{}
 	isoBasePath              string
 	activeDiskImageDownloads sync.Map // tracks in-progress DiskImage downloads by name
 }
 
 // New creates a new controller
-func New(k8sClient *k8s.Client) *Controller {
+func New(k8sClient KubernetesClient) *Controller {
 	return &Controller{
 		k8sClient: k8sClient,
 		stopCh:    make(chan struct{}),

--- a/internal/controller/interfaces.go
+++ b/internal/controller/interfaces.go
@@ -1,0 +1,26 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/isoboot/isoboot/internal/k8s"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// KubernetesClient abstracts the Kubernetes operations used by the controller.
+// *k8s.Client satisfies this interface implicitly.
+type KubernetesClient interface {
+	ListProvisions(ctx context.Context) ([]*k8s.Provision, error)
+	GetProvision(ctx context.Context, name string) (*k8s.Provision, error)
+	UpdateProvisionStatus(ctx context.Context, name, phase, message, ip string) error
+	ListProvisionsByMachine(ctx context.Context, machineRef string) ([]*k8s.Provision, error)
+	GetMachine(ctx context.Context, name string) (*k8s.Machine, error)
+	FindMachineByMAC(ctx context.Context, mac string) (*k8s.Machine, error)
+	GetBootTarget(ctx context.Context, name string) (*k8s.BootTarget, error)
+	GetResponseTemplate(ctx context.Context, name string) (*k8s.ResponseTemplate, error)
+	GetConfigMap(ctx context.Context, name string) (*corev1.ConfigMap, error)
+	GetSecret(ctx context.Context, name string) (*corev1.Secret, error)
+	GetDiskImage(ctx context.Context, name string) (*k8s.DiskImage, error)
+	ListDiskImages(ctx context.Context) ([]*k8s.DiskImage, error)
+	UpdateDiskImageStatus(ctx context.Context, name string, status *k8s.DiskImageStatus) error
+}


### PR DESCRIPTION
## Summary
- Add `KubernetesClient` interface in `internal/controller/interfaces.go` covering all 13 k8s methods used across controller.go, grpc.go, and diskimage.go
- Change `Controller.k8sClient` field from `*k8s.Client` to `KubernetesClient` interface
- `*k8s.Client` satisfies the interface implicitly — zero changes to callers

Part of #74, closes #77

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (no behavior change, only type widening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)