### PR TITLE
Update boot handler for BootMedia

### DIFF
--- a/cmd/isoboot-http/main.go
+++ b/cmd/isoboot-http/main.go
@@ -97,7 +97,7 @@ func main() {
 	})
 
 	// Boot handlers
-	bootHandler := handlers.NewBootHandler(host, port, proxyPort, ctrlClient, templatesConfigMap)
+	bootHandler := handlers.NewBootHandler(host, proxyPort, ctrlClient, templatesConfigMap)
 	bootHandler.RegisterRoutes(mux)
 
 	// ISO content handlers
@@ -105,7 +105,7 @@ func main() {
 	isoHandler.RegisterRoutes(mux)
 
 	// Answer file handlers
-	answerHandler := handlers.NewAnswerHandler(host, port, proxyPort, ctrlClient)
+	answerHandler := handlers.NewAnswerHandler(host, proxyPort, ctrlClient)
 	answerHandler.RegisterRoutes(mux)
 
 	// Start server

--- a/internal/handlers/answer.go
+++ b/internal/handlers/answer.go
@@ -21,15 +21,13 @@ type AnswerClient interface {
 
 type AnswerHandler struct {
 	host       string
-	port       string
 	proxyPort  string
 	ctrlClient AnswerClient
 }
 
-func NewAnswerHandler(host, port, proxyPort string, ctrlClient AnswerClient) *AnswerHandler {
+func NewAnswerHandler(host, proxyPort string, ctrlClient AnswerClient) *AnswerHandler {
 	return &AnswerHandler{
 		host:       host,
-		port:       port,
 		proxyPort:  proxyPort,
 		ctrlClient: ctrlClient,
 	}
@@ -127,7 +125,7 @@ func (h *AnswerHandler) ServeAnswer(w http.ResponseWriter, r *http.Request) {
 
 	// Add system variables
 	data["Host"] = h.host
-	data["Port"] = h.port
+	data["Port"] = portFromRequest(r)
 	data["Hostname"] = provision.MachineRef
 	data["Target"] = provision.BootTargetRef
 

--- a/internal/handlers/answer_test.go
+++ b/internal/handlers/answer_test.go
@@ -65,7 +65,7 @@ func TestServeAnswer_Success(t *testing.T) {
 		},
 	}
 
-	h := NewAnswerHandler("10.0.0.1", "8080", "3128", mock)
+	h := NewAnswerHandler("10.0.0.1", "3128", mock)
 	req := httptest.NewRequest("GET", "/answer/prov-1/preseed.cfg", nil)
 	w := httptest.NewRecorder()
 
@@ -87,7 +87,7 @@ func TestServeAnswer_Success(t *testing.T) {
 }
 
 func TestServeAnswer_InvalidPath(t *testing.T) {
-	h := NewAnswerHandler("10.0.0.1", "8080", "3128", &mockAnswerClient{})
+	h := NewAnswerHandler("10.0.0.1", "3128", &mockAnswerClient{})
 	req := httptest.NewRequest("GET", "/answer/only-one-segment", nil)
 	w := httptest.NewRecorder()
 
@@ -105,7 +105,7 @@ func TestServeAnswer_ProvisionNotFound(t *testing.T) {
 		},
 	}
 
-	h := NewAnswerHandler("10.0.0.1", "8080", "3128", mock)
+	h := NewAnswerHandler("10.0.0.1", "3128", mock)
 	req := httptest.NewRequest("GET", "/answer/missing-prov/preseed.cfg", nil)
 	w := httptest.NewRecorder()
 
@@ -123,7 +123,7 @@ func TestServeAnswer_GRPCError(t *testing.T) {
 		},
 	}
 
-	h := NewAnswerHandler("10.0.0.1", "8080", "3128", mock)
+	h := NewAnswerHandler("10.0.0.1", "3128", mock)
 	req := httptest.NewRequest("GET", "/answer/prov-1/preseed.cfg", nil)
 	w := httptest.NewRecorder()
 
@@ -149,7 +149,7 @@ func TestServeAnswer_FileNotInTemplate(t *testing.T) {
 		},
 	}
 
-	h := NewAnswerHandler("10.0.0.1", "8080", "3128", mock)
+	h := NewAnswerHandler("10.0.0.1", "3128", mock)
 	req := httptest.NewRequest("GET", "/answer/prov-1/nonexistent.cfg", nil)
 	w := httptest.NewRecorder()
 

--- a/internal/handlers/boot_test.go
+++ b/internal/handlers/boot_test.go
@@ -17,7 +17,7 @@ type mockBootClient struct {
 	getMachineByMAC        func(ctx context.Context, mac string) (string, error)
 	getProvisionsByMachine func(ctx context.Context, machineName string) ([]controllerclient.ProvisionSummary, error)
 	getBootTarget          func(ctx context.Context, name string) (*controllerclient.BootTargetInfo, error)
-	getDiskImage           func(ctx context.Context, name string) (*controllerclient.DiskImageInfo, error)
+	getBootMedia           func(ctx context.Context, name string) (*controllerclient.BootMediaInfo, error)
 	updateProvisionStatus  func(ctx context.Context, name, status, message, ip string) error
 }
 
@@ -33,11 +33,11 @@ func (m *mockBootClient) GetProvisionsByMachine(ctx context.Context, machineName
 func (m *mockBootClient) GetBootTarget(ctx context.Context, name string) (*controllerclient.BootTargetInfo, error) {
 	return m.getBootTarget(ctx, name)
 }
-func (m *mockBootClient) GetDiskImage(ctx context.Context, name string) (*controllerclient.DiskImageInfo, error) {
-	if m.getDiskImage != nil {
-		return m.getDiskImage(ctx, name)
+func (m *mockBootClient) GetBootMedia(ctx context.Context, name string) (*controllerclient.BootMediaInfo, error) {
+	if m.getBootMedia != nil {
+		return m.getBootMedia(ctx, name)
 	}
-	return nil, fmt.Errorf("diskimage %s: %w", name, controllerclient.ErrNotFound)
+	return &controllerclient.BootMediaInfo{}, nil
 }
 func (m *mockBootClient) UpdateProvisionStatus(ctx context.Context, name, status, message, ip string) error {
 	return m.updateProvisionStatus(ctx, name, status, message, ip)
@@ -88,48 +88,29 @@ func TestSplitHostDomain(t *testing.T) {
 	}
 }
 
-func TestServeBootIPXE_Success(t *testing.T) {
-	mock := &mockBootClient{
-		getConfigMapValue: func(ctx context.Context, configMapName, key string) (string, error) {
-			if configMapName == "isoboot-templates" && key == "boot.ipxe" {
-				return "#!ipxe\nchain http://{{ .Host }}:{{ .Port }}/boot/conditional-boot?mac=${net0/mac}\n", nil
+func TestPortFromRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		xPort    string
+		expected string
+	}{
+		{"X-Forwarded-Port takes precedence", "example.com:9090", "8080", "8080"},
+		{"Host header port", "example.com:9090", "", "9090"},
+		{"Default port 80", "example.com", "", "80"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.Host = tt.host
+			if tt.xPort != "" {
+				req.Header.Set("X-Forwarded-Port", tt.xPort)
 			}
-			return "", fmt.Errorf("not found")
-		},
-	}
-
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "isoboot-templates")
-	req := httptest.NewRequest("GET", "/boot/boot.ipxe", nil)
-	w := httptest.NewRecorder()
-
-	h.ServeBootIPXE(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
-	}
-	if !strings.Contains(w.Body.String(), "10.0.0.1:8080") {
-		t.Errorf("expected host:port in body, got %q", w.Body.String())
-	}
-	if w.Header().Get("Content-Length") == "" {
-		t.Error("expected Content-Length header")
-	}
-}
-
-func TestServeBootIPXE_TemplateError(t *testing.T) {
-	mock := &mockBootClient{
-		getConfigMapValue: func(ctx context.Context, configMapName, key string) (string, error) {
-			return "", fmt.Errorf("configmap not found")
-		},
-	}
-
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "missing-cm")
-	req := httptest.NewRequest("GET", "/boot/boot.ipxe", nil)
-	w := httptest.NewRecorder()
-
-	h.ServeBootIPXE(w, req)
-
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d", w.Code)
+			got := portFromRequest(req)
+			if got != tt.expected {
+				t.Errorf("portFromRequest() = %q, want %q", got, tt.expected)
+			}
+		})
 	}
 }
 
@@ -146,8 +127,12 @@ func TestServeConditionalBoot_PendingProvision(t *testing.T) {
 		},
 		getBootTarget: func(ctx context.Context, name string) (*controllerclient.BootTargetInfo, error) {
 			return &controllerclient.BootTargetInfo{
-				Template: "#!ipxe\nkernel http://{{ .Host }}:{{ .Port }}/iso/content/{{ .BootTarget }}/mini.iso/linux\nboot\n",
+				BootMediaRef: "debian-13-media",
+				Template:     "#!ipxe\nkernel http://{{ .Host }}:{{ .Port }}/files/{{ .BootMedia }}/{{ .KernelFilename }}\nboot\n",
 			}, nil
+		},
+		getBootMedia: func(ctx context.Context, name string) (*controllerclient.BootMediaInfo, error) {
+			return &controllerclient.BootMediaInfo{KernelFilename: "linux", InitrdFilename: "initrd.gz"}, nil
 		},
 		updateProvisionStatus: func(ctx context.Context, name, status, message, ip string) error {
 			updatedName = name
@@ -156,8 +141,9 @@ func TestServeConditionalBoot_PendingProvision(t *testing.T) {
 		},
 	}
 
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "isoboot-templates")
+	h := NewBootHandler("10.0.0.1", "3128", mock, "isoboot-templates")
 	req := httptest.NewRequest("GET", "/boot/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
+	req.Header.Set("X-Forwarded-Port", "8080")
 	w := httptest.NewRecorder()
 
 	h.ServeConditionalBoot(w, req)
@@ -177,47 +163,7 @@ func TestServeConditionalBoot_PendingProvision(t *testing.T) {
 	}
 }
 
-func TestServeConditionalBoot_DiskImageFile(t *testing.T) {
-	mock := &mockBootClient{
-		getMachineByMAC: func(ctx context.Context, mac string) (string, error) {
-			return "vm-01.lan", nil
-		},
-		getProvisionsByMachine: func(ctx context.Context, machineName string) ([]controllerclient.ProvisionSummary, error) {
-			return []controllerclient.ProvisionSummary{
-				{Name: "prov-1", Status: "Pending", BootTargetRef: "ubuntu-24"},
-			}, nil
-		},
-		getBootTarget: func(ctx context.Context, name string) (*controllerclient.BootTargetInfo, error) {
-			return &controllerclient.BootTargetInfo{
-				DiskImage: "ubuntu-iso",
-				Template:  "url=http://{{ .Host }}:{{ .Port }}/iso/download/{{ .BootTarget }}/{{ .DiskImageFile }}",
-			}, nil
-		},
-		getDiskImage: func(ctx context.Context, name string) (*controllerclient.DiskImageInfo, error) {
-			return &controllerclient.DiskImageInfo{ISOFilename: "ubuntu-24.04.1-live-server-amd64.iso"}, nil
-		},
-		updateProvisionStatus: func(ctx context.Context, name, status, message, ip string) error {
-			return nil
-		},
-	}
-
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "cm")
-	req := httptest.NewRequest("GET", "/boot/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
-	w := httptest.NewRecorder()
-
-	h.ServeConditionalBoot(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
-	}
-	body := w.Body.String()
-	if !strings.Contains(body, "ubuntu-24.04.1-live-server-amd64.iso") {
-		t.Errorf("expected DiskImageFile in body, got %q", body)
-	}
-}
-
-func TestServeConditionalBoot_DiskImageNotFound(t *testing.T) {
-	// When DiskImage is not found, DiskImageFile should be empty but boot should still succeed
+func TestServeConditionalBoot_BootMediaAndFirmwareRendered(t *testing.T) {
 	mock := &mockBootClient{
 		getMachineByMAC: func(ctx context.Context, mac string) (string, error) {
 			return "vm-01.lan", nil
@@ -229,26 +175,79 @@ func TestServeConditionalBoot_DiskImageNotFound(t *testing.T) {
 		},
 		getBootTarget: func(ctx context.Context, name string) (*controllerclient.BootTargetInfo, error) {
 			return &controllerclient.BootTargetInfo{
-				DiskImage: "missing-image",
-				Template:  "#!ipxe\nboot\n",
+				BootMediaRef: "debian-media",
+				UseFirmware:  true,
+				Template:     "media={{ .BootMedia }} fw={{ .UseFirmware }}",
 			}, nil
 		},
-		getDiskImage: func(ctx context.Context, name string) (*controllerclient.DiskImageInfo, error) {
-			return nil, fmt.Errorf("diskimage %s: %w", name, controllerclient.ErrNotFound)
+		getBootMedia: func(ctx context.Context, name string) (*controllerclient.BootMediaInfo, error) {
+			return &controllerclient.BootMediaInfo{KernelFilename: "linux", InitrdFilename: "initrd.gz", HasFirmware: true}, nil
 		},
 		updateProvisionStatus: func(ctx context.Context, name, status, message, ip string) error {
 			return nil
 		},
 	}
 
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "cm")
+	h := NewBootHandler("10.0.0.1", "3128", mock, "cm")
 	req := httptest.NewRequest("GET", "/boot/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 
 	h.ServeConditionalBoot(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 (DiskImage not found is non-fatal), got %d", w.Code)
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "media=debian-media") {
+		t.Errorf("expected BootMedia in body, got %q", body)
+	}
+	if !strings.Contains(body, "fw=true") {
+		t.Errorf("expected UseFirmware=true in body, got %q", body)
+	}
+}
+
+func TestServeConditionalBoot_NewTemplateVariables(t *testing.T) {
+	mock := &mockBootClient{
+		getMachineByMAC: func(ctx context.Context, mac string) (string, error) {
+			return "vm-01.lan", nil
+		},
+		getProvisionsByMachine: func(ctx context.Context, machineName string) ([]controllerclient.ProvisionSummary, error) {
+			return []controllerclient.ProvisionSummary{
+				{Name: "prov-1", Status: "Pending", BootTargetRef: "ubuntu-24"},
+			}, nil
+		},
+		getBootTarget: func(ctx context.Context, name string) (*controllerclient.BootTargetInfo, error) {
+			return &controllerclient.BootTargetInfo{
+				BootMediaRef: "ubuntu-media",
+				Template:     "kernel={{ .KernelFilename }} initrd={{ .InitrdFilename }} fw={{ .HasFirmware }}",
+			}, nil
+		},
+		getBootMedia: func(ctx context.Context, name string) (*controllerclient.BootMediaInfo, error) {
+			return &controllerclient.BootMediaInfo{KernelFilename: "vmlinuz", InitrdFilename: "initrd", HasFirmware: false}, nil
+		},
+		updateProvisionStatus: func(ctx context.Context, name, status, message, ip string) error {
+			return nil
+		},
+	}
+
+	h := NewBootHandler("10.0.0.1", "3128", mock, "cm")
+	req := httptest.NewRequest("GET", "/boot/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeConditionalBoot(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "kernel=vmlinuz") {
+		t.Errorf("expected KernelFilename in body, got %q", body)
+	}
+	if !strings.Contains(body, "initrd=initrd") {
+		t.Errorf("expected InitrdFilename in body, got %q", body)
+	}
+	if !strings.Contains(body, "fw=false") {
+		t.Errorf("expected HasFirmware=false in body, got %q", body)
 	}
 }
 
@@ -259,7 +258,7 @@ func TestServeConditionalBoot_NoMachine(t *testing.T) {
 		},
 	}
 
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "cm")
+	h := NewBootHandler("10.0.0.1", "3128", mock, "cm")
 	req := httptest.NewRequest("GET", "/boot/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 
@@ -282,7 +281,7 @@ func TestServeConditionalBoot_NoPendingProvision(t *testing.T) {
 		},
 	}
 
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "cm")
+	h := NewBootHandler("10.0.0.1", "3128", mock, "cm")
 	req := httptest.NewRequest("GET", "/boot/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 
@@ -311,7 +310,7 @@ func TestServeBootDone_Success(t *testing.T) {
 		},
 	}
 
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "cm")
+	h := NewBootHandler("10.0.0.1", "3128", mock, "cm")
 	req := httptest.NewRequest("GET", "/boot/done?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 
@@ -329,7 +328,7 @@ func TestServeBootDone_Success(t *testing.T) {
 }
 
 func TestServeConditionalBoot_NoMAC(t *testing.T) {
-	h := NewBootHandler("10.0.0.1", "8080", "3128", &mockBootClient{}, "cm")
+	h := NewBootHandler("10.0.0.1", "3128", &mockBootClient{}, "cm")
 	req := httptest.NewRequest("GET", "/boot/conditional-boot", nil)
 	w := httptest.NewRecorder()
 
@@ -360,7 +359,7 @@ func TestServeConditionalBoot_EmptyStatusTreatedAsPending(t *testing.T) {
 		},
 	}
 
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "cm")
+	h := NewBootHandler("10.0.0.1", "3128", mock, "cm")
 	req := httptest.NewRequest("GET", "/boot/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 
@@ -372,7 +371,7 @@ func TestServeConditionalBoot_EmptyStatusTreatedAsPending(t *testing.T) {
 }
 
 func TestServeBootDone_NoMAC(t *testing.T) {
-	h := NewBootHandler("10.0.0.1", "8080", "3128", &mockBootClient{}, "cm")
+	h := NewBootHandler("10.0.0.1", "3128", &mockBootClient{}, "cm")
 	req := httptest.NewRequest("GET", "/boot/done", nil)
 	w := httptest.NewRecorder()
 
@@ -398,7 +397,7 @@ func TestServeBootDone_UpdateStatusError(t *testing.T) {
 		},
 	}
 
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "cm")
+	h := NewBootHandler("10.0.0.1", "3128", mock, "cm")
 	req := httptest.NewRequest("GET", "/boot/done?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 
@@ -421,7 +420,7 @@ func TestServeBootDone_NoInProgress(t *testing.T) {
 		},
 	}
 
-	h := NewBootHandler("10.0.0.1", "8080", "3128", mock, "cm")
+	h := NewBootHandler("10.0.0.1", "3128", mock, "cm")
 	req := httptest.NewRequest("GET", "/boot/done?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 


### PR DESCRIPTION
## Summary
- Replace `GetDiskImage` with `GetBootMedia` in BootClient interface and ServeConditionalBoot handler
- Add new boot template variables: `BootMedia`, `UseFirmware`, `KernelFilename`, `InitrdFilename`, `HasFirmware`
- Remove `DiskImageFile` template variable
- Remove `ServeBootIPXE` endpoint and `/boot/boot.ipxe` route
- Remove `port` field from `BootHandler` and `AnswerHandler`; use `portFromRequest()` for dynamic port detection via `X-Forwarded-Port` header

## Test plan
- [x] `go test ./...` passes
- [x] New tests for `portFromRequest()`, BootMedia template variables, firmware rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)