### PR TITLE
Update CLAUDE.md docs for BootMedia architecture

### DIFF
--- a/internal/controller/CLAUDE.md
+++ b/internal/controller/CLAUDE.md
@@ -5,17 +5,24 @@ Controller reconciliation logic for isoboot-controller.
 ## Components
 
 ### Controller (controller.go)
-Main reconciliation loop that watches Provision CRDs:
-- Validates references (Machine, BootTarget, ResponseTemplate, ConfigMaps, Secrets)
+Main reconciliation loop that watches Provision and BootMedia CRDs:
+- Validates references (Machine, BootTarget, BootMedia, ResponseTemplate, ConfigMaps, Secrets)
+- Two-step readiness check: Provision → BootTarget → BootMedia (status must be Complete)
 - Manages status transitions: Pending → InProgress → Complete/Failed
-- Renders templates with merged ConfigMap/Secret data
+- WaitingForBootMedia status when BootMedia is not yet Complete
 - Timeout handling for stuck InProgress provisions (30 min default)
 
-### DiskImage Downloader (diskimage.go)
-Downloads and caches ISO/firmware files for BootTargets:
-- Verifies checksums (SHA256/SHA512) if provided
-- Tracks download progress in DiskImage status
-- Extracts ISO contents for serving
+### BootMedia Downloader (bootmedia.go)
+Downloads and caches files for BootMedia resources. Four download flows:
+1. **Direct** (kernel + initrd URLs, no firmware): Downloads to flat `{bmDir}/` layout
+2. **Direct + firmware**: Downloads kernel to `{bmDir}/`, initrd to `{bmDir}/no-firmware/`, firmware to temp, concatenates initrd + firmware → `{bmDir}/with-firmware/`
+3. **ISO** (ISO URL + extraction paths, no firmware): Downloads ISO to temp, extracts kernel/initrd to flat `{bmDir}/` layout
+4. **ISO + firmware**: Same as ISO but with firmware subdirectory layout
+
+Features:
+- Verifies checksums (SHA256) if provided
+- Tracks download progress per named field in BootMedia status (kernel, initrd, iso, firmware, firmwareInitrd)
+- Firmware concatenation: `no-firmware/initrd + firmware.cpio.gz → with-firmware/initrd`
 
 ### gRPC Server (grpc.go)
 Exposes primitive CRD accessors to isoboot-http:
@@ -26,13 +33,20 @@ Exposes primitive CRD accessors to isoboot-http:
 - `GetConfigMaps` - Get merged ConfigMap data
 - `GetSecrets` - Get merged Secret data
 - `GetResponseTemplate` - Get response template by name
-- `GetBootTarget` - Get boot target by name
+- `GetBootTarget` - Get boot target by name (returns template, bootMediaRef, useFirmware)
+- `GetBootMedia` - Get boot media by name (returns kernelFilename, initrdFilename, hasFirmware)
 - `GetConfigMapValue` - Get single value from ConfigMap
 
 ### SSH Key Derivation (sshkeys.go)
 Derives public keys from private SSH host keys in secrets:
 - Supports RSA, ECDSA, Ed25519 key types
 - Auto-generates `.ssh_host_*_key_pub` template variables
+
+## Testing
+
+Tests use controller-runtime's fake client (`sigs.k8s.io/controller-runtime/pkg/client/fake`) with
+`WithStatusSubresource(&k8s.Provision{}, &k8s.BootMedia{})` for proper status subresource testing.
+See `testhelpers_test.go` for shared test setup (`newTestTypedClient`, `newConfigMap`, `newSecret`).
 
 ## Validation
 

--- a/internal/handlers/CLAUDE.md
+++ b/internal/handlers/CLAUDE.md
@@ -5,15 +5,12 @@ HTTP handlers for isoboot-http server.
 ## Handlers
 
 ### BootHandler (boot.go)
-- `GET /boot/boot.ipxe` - Initial iPXE script (chains to conditional-boot)
 - `GET /boot/conditional-boot?mac=xx-xx-xx-xx-xx-xx` - Returns BootTarget template if Provision exists, 404 otherwise
 - `GET /boot/done?mac={mac}` - Marks Provision as completed (call from preseed late_command with `{{ .MAC }}`)
 
-Template variables: Host, Port, MachineName, Hostname, Domain, BootTarget, ProvisionName
+Template variables: Host, Port, MachineName, Hostname, Domain, BootTarget, BootMedia, UseFirmware, ProvisionName, KernelFilename, InitrdFilename, HasFirmware
 
-### ISOHandler (iso.go)
-- `GET /iso/content/{bootTarget}/{isoFile}/{path...}` - Serves extracted ISO contents
-- Firmware merging: If BootTarget has `includeFirmwarePath` and path matches, appends firmware.cpio.gz
+Port detection: `portFromRequest(r)` reads `X-Forwarded-Port` header (set by nginx), falls back to port from `Host` header, defaults to "80".
 
 ### AnswerHandler (answer.go)
 - `GET /answer/{provisionName}/{filename}` - Serves rendered ResponseTemplate files


### PR DESCRIPTION
## Summary
- Update root `CLAUDE.md`: add BootMedia/BootTarget CRD architecture docs, directory structure, new template variables (BootMedia, KernelFilename, etc.), PR review tips, updated testing guidelines
- Update `internal/controller/CLAUDE.md`: replace DiskImage downloader with BootMedia downloader docs (4 download flows), add GetBootMedia RPC, document controller-runtime test setup
- Update `internal/handlers/CLAUDE.md`: remove ISO handler docs, add new boot template variables, document port detection

## Test plan
- [x] Documentation-only change, no code modified

Final PR in the stacked series splitting #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)