### PR TITLE
Add configurable HTTP client with timeouts to downloader

### DIFF
--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -2,15 +2,57 @@ package downloader
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// customHeaderTransport is a test helper that injects a custom header into
+// every request, allowing tests to verify that a specific client was used.
+type customHeaderTransport struct {
+	header string
+	value  string
+	base   http.RoundTripper
+}
+
+func (t *customHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set(t.header, t.value)
+	return t.base.RoundTrip(req)
+}
+
+var _ = Describe("NewDefaultClient", func() {
+	It("should return a client with expected transport timeouts", func() {
+		client := NewDefaultClient()
+		Expect(client).NotTo(BeNil())
+		Expect(client.Timeout).To(Equal(time.Duration(0)), "no overall timeout so large downloads are not interrupted")
+
+		transport, ok := client.Transport.(*http.Transport)
+		Expect(ok).To(BeTrue())
+		Expect(transport.TLSHandshakeTimeout).To(Equal(10 * time.Second))
+		Expect(transport.ResponseHeaderTimeout).To(Equal(30 * time.Second))
+	})
+
+	It("should produce a working client", func() {
+		expected := "hello from custom client test"
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(expected)) //nolint:errcheck // test handler
+		}))
+		defer ts.Close()
+
+		client := NewDefaultClient()
+		data, err := FetchContent(context.Background(), client, ts.URL)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal(expected))
+	})
+})
 
 var _ = Describe("Download", func() {
 	It("should download file content to the destination path", func() {
@@ -23,7 +65,7 @@ var _ = Describe("Download", func() {
 		dir := GinkgoT().TempDir()
 		destPath := filepath.Join(dir, "downloaded-file")
 
-		Expect(Download(context.Background(), ts.URL, destPath)).To(Succeed())
+		Expect(Download(context.Background(), nil, ts.URL, destPath)).To(Succeed())
 
 		data, err := os.ReadFile(destPath)
 		Expect(err).NotTo(HaveOccurred())
@@ -40,7 +82,7 @@ var _ = Describe("Download", func() {
 		dir := GinkgoT().TempDir()
 		destPath := filepath.Join(dir, "sub", "dir", "file")
 
-		Expect(Download(context.Background(), ts.URL, destPath)).To(Succeed())
+		Expect(Download(context.Background(), nil, ts.URL, destPath)).To(Succeed())
 
 		data, err := os.ReadFile(destPath)
 		Expect(err).NotTo(HaveOccurred())
@@ -56,7 +98,7 @@ var _ = Describe("Download", func() {
 		dir := GinkgoT().TempDir()
 		destPath := filepath.Join(dir, "should-not-exist")
 
-		Expect(Download(context.Background(), ts.URL, destPath)).To(HaveOccurred())
+		Expect(Download(context.Background(), nil, ts.URL, destPath)).To(HaveOccurred())
 
 		_, statErr := os.Stat(destPath)
 		Expect(os.IsNotExist(statErr)).To(BeTrue())
@@ -84,7 +126,7 @@ var _ = Describe("Download", func() {
 		dir := GinkgoT().TempDir()
 		destPath := filepath.Join(dir, "should-not-exist")
 
-		Expect(Download(context.Background(), ts.URL, destPath)).To(HaveOccurred())
+		Expect(Download(context.Background(), nil, ts.URL, destPath)).To(HaveOccurred())
 
 		_, statErr := os.Stat(destPath)
 		Expect(os.IsNotExist(statErr)).To(BeTrue())
@@ -102,10 +144,57 @@ var _ = Describe("Download", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // cancel immediately
 
-		Expect(Download(ctx, ts.URL, destPath)).To(HaveOccurred())
+		Expect(Download(ctx, nil, ts.URL, destPath)).To(HaveOccurred())
 
 		_, statErr := os.Stat(destPath)
 		Expect(os.IsNotExist(statErr)).To(BeTrue())
+	})
+
+	It("should use a provided custom client", func() {
+		var receivedUA string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedUA = r.Header.Get("User-Agent")
+			w.Write([]byte("custom")) //nolint:errcheck // test handler
+		}))
+		defer ts.Close()
+
+		custom := &http.Client{
+			Transport: &customHeaderTransport{
+				header: "User-Agent",
+				value:  "test-agent",
+				base:   http.DefaultTransport,
+			},
+		}
+
+		dir := GinkgoT().TempDir()
+		destPath := filepath.Join(dir, "custom-client-file")
+
+		Expect(Download(context.Background(), custom, ts.URL, destPath)).To(Succeed())
+		Expect(receivedUA).To(Equal("test-agent"))
+
+		data, err := os.ReadFile(destPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("custom"))
+	})
+
+	It("should respect custom client timeouts", func() {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(500 * time.Millisecond)
+			w.Write([]byte("slow")) //nolint:errcheck // test handler
+		}))
+		defer ts.Close()
+
+		short := &http.Client{
+			Transport: &http.Transport{
+				DialContext: (&net.Dialer{Timeout: 1 * time.Second}).DialContext,
+			},
+			Timeout: 100 * time.Millisecond,
+		}
+
+		dir := GinkgoT().TempDir()
+		destPath := filepath.Join(dir, "should-not-exist")
+
+		Expect(Download(context.Background(), short, ts.URL, destPath)).To(HaveOccurred())
 	})
 })
 
@@ -117,7 +206,7 @@ var _ = Describe("FetchContent", func() {
 		}))
 		defer ts.Close()
 
-		data, err := FetchContent(context.Background(), ts.URL)
+		data, err := FetchContent(context.Background(), nil, ts.URL)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(data)).To(Equal(expected))
 	})
@@ -128,7 +217,7 @@ var _ = Describe("FetchContent", func() {
 		}))
 		defer ts.Close()
 
-		_, err := FetchContent(context.Background(), ts.URL)
+		_, err := FetchContent(context.Background(), nil, ts.URL)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -139,7 +228,7 @@ var _ = Describe("FetchContent", func() {
 		}))
 		defer ts.Close()
 
-		_, err := FetchContent(context.Background(), ts.URL)
+		_, err := FetchContent(context.Background(), nil, ts.URL)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -152,7 +241,30 @@ var _ = Describe("FetchContent", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // cancel immediately
 
-		_, err := FetchContent(ctx, ts.URL)
+		_, err := FetchContent(ctx, nil, ts.URL)
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("should use a provided custom client", func() {
+		var receivedUA string
+		expected := "fetched with custom"
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedUA = r.Header.Get("User-Agent")
+			w.Write([]byte(expected)) //nolint:errcheck // test handler
+		}))
+		defer ts.Close()
+
+		custom := &http.Client{
+			Transport: &customHeaderTransport{
+				header: "User-Agent",
+				value:  "fetch-agent",
+				base:   http.DefaultTransport,
+			},
+		}
+
+		data, err := FetchContent(context.Background(), custom, ts.URL)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal(expected))
+		Expect(receivedUA).To(Equal("fetch-agent"))
 	})
 })


### PR DESCRIPTION
## Summary

- Added `NewDefaultClient()` to `internal/downloader` that returns an `*http.Client` with 30s dial timeout, 10s TLS handshake timeout, and 30s response header timeout
- Changed `Download` and `FetchContent` signatures to accept `*http.Client` — when `nil` is passed, `NewDefaultClient()` is used automatically
- No overall `Timeout` is set so large file downloads are not interrupted; callers use context deadlines for per-request limits

## Test table

| Test | Type | Validates |
|------|------|-----------|
| NewDefaultClient / should return a client with expected transport timeouts | Positive | Transport fields match expected timeout values |
| NewDefaultClient / should produce a working client | Positive | Client can complete a real HTTP request |
| Download / should download file content to the destination path | Positive | Basic download with nil client works |
| Download / should create intermediate directories | Positive | MkdirAll for nested dest path |
| Download / should return error on 404 and not leave a file | Negative | HTTP error propagated, no leftover file |
| Download / should not leave partial files on truncated download | Negative | Abrupt close cleaned up |
| Download / should return error on canceled context | Negative | Context cancellation propagated |
| Download / should use a provided custom client | Positive | Custom transport header is sent |
| Download / should respect custom client timeouts | Negative | Short client timeout causes error on slow server |
| FetchContent / should fetch and return content | Positive | Basic fetch with nil client works |
| FetchContent / should return error on 404 | Negative | HTTP error propagated |
| FetchContent / should reject responses exceeding the size limit | Negative | 10 MB limit enforced |
| FetchContent / should return error on canceled context | Negative | Context cancellation propagated |
| FetchContent / should use a provided custom client | Positive | Custom transport header is sent |

## Test plan

```
14 Passed | 0 Failed | 0 Pending | 0 Skipped
```

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)