### PR TITLE
Improve scaffolded e2e and test utility code

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -58,8 +58,8 @@ var _ = BeforeSuite(func() {
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
-	if getFirstFoundEnvTestBinaryDir() != "" {
-		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	if dir := getFirstFoundEnvTestBinaryDir(); dir != "" {
+		testEnv.BinaryAssetsDirectory = dir
 	}
 
 	// cfg is defined in this file globally.

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -18,12 +18,11 @@ const (
 
 // Run executes the provided command within this context
 func Run(cmd *exec.Cmd) (string, error) {
-	dir, _ := GetProjectDir()
-	cmd.Dir = dir
-
-	if err := os.Chdir(cmd.Dir); err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "chdir dir: %q\n", err)
+	dir, err := GetProjectDir()
+	if err != nil {
+		return "", fmt.Errorf("getting project dir: %w", err)
 	}
+	cmd.Dir = dir
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")


### PR DESCRIPTION
## Summary

- Make namespace and ClusterRoleBinding creation idempotent (dry-run + apply pattern)
- Pin curl image to `8.5.0` instead of `latest`
- Use unique temp files with cleanup via `os.CreateTemp` and `defer os.Remove`
- Handle `GetProjectDir()` errors in `Run()` instead of ignoring them
- Remove unnecessary `os.Chdir()` (cmd.Dir already sets working directory)
- Call `getFirstFoundEnvTestBinaryDir()` once instead of twice

Fixes #149

## Why these changes matter

| Issue | Scenario | Before | After |
|-------|----------|--------|-------|
| ClusterRoleBinding | Run e2e tests twice | 1st run: passes. 2nd run: `error: clusterrolebinding already exists` → test fails | Both runs pass |
| Namespace | Run e2e tests twice | 1st run: passes. 2nd run: `error: namespace already exists` → test fails | Both runs pass |
| curl:latest | Image maintainer pushes update | Random CI failure someday, works today | Same curl version forever |
| Temp file | Run tests 100 times | 100 orphan files in `/tmp` | 0 files left behind |
| os.Chdir | `GetProjectDir()` fails | Error silently ignored, confusing failure later | Test fails immediately with clear error |
| Double function call | Normal test run | Reads `bin/k8s/` directory twice | Reads it once |

**Note:** These are kubebuilder-scaffolded test infrastructure files. The e2e tests currently only verify "does the controller pod start and serve metrics" — no actual BootSource/BootTarget functionality is tested yet.

## Test plan

- [x] `make build` compiles
- [x] `make test` passes all 67 tests (27 checksum + 20 controller + 14 downloader + 6 isoextract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)