### PR TITLE
Add comprehensive integration tests for BootSource controller

### DIFF
--- a/internal/controller/bootsource_integration_test.go
+++ b/internal/controller/bootsource_integration_test.go
@@ -50,6 +50,7 @@ type mockHTTPServer struct {
 	initrdDownloads   int
 	firmwareDownloads int
 	isoDownloads      int
+	checksumResponses map[string]string // path -> response content for custom checksum endpoints
 }
 
 // newMockHTTPServer creates a mock HTTPS server with fake boot resources.
@@ -104,25 +105,39 @@ func newMockHTTPServer() *mockHTTPServer {
 	mux.HandleFunc("/firmware", serveResource(&m.FirmwareContent, &m.firmwareDownloads, &m.failFirmware))
 	mux.HandleFunc("/boot.iso", serveResource(&m.ISOContent, &m.isoDownloads, &m.failISO))
 
-	mux.HandleFunc("/SHA256SUMS", func(w http.ResponseWriter, _ *http.Request) {
+	// Checksum handler: serves custom responses from checksumResponses map, or default SHA256SUMS
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		m.mu.RLock()
+		customResponse, hasCustom := m.checksumResponses[r.URL.Path]
 		fail := m.failChecksumURL
 		wrongHash := m.returnWrongHash
 		m.mu.RUnlock()
 
-		if fail {
-			http.Error(w, "not found", http.StatusNotFound)
+		// Handle custom checksum responses
+		if hasCustom {
+			_, _ = w.Write([]byte(customResponse))
 			return
 		}
 
-		kernelHash, initrdHash := m.KernelSHA256, m.InitrdSHA256
-		if wrongHash {
-			kernelHash = "0000000000000000000000000000000000000000000000000000000000000000"
-			initrdHash = "1111111111111111111111111111111111111111111111111111111111111111"
+		// Handle default SHA256SUMS path
+		if r.URL.Path == "/SHA256SUMS" {
+			if fail {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+
+			kernelHash, initrdHash := m.KernelSHA256, m.InitrdSHA256
+			if wrongHash {
+				kernelHash = "0000000000000000000000000000000000000000000000000000000000000000"
+				initrdHash = "1111111111111111111111111111111111111111111111111111111111111111"
+			}
+
+			_, _ = fmt.Fprintf(w, "%s  kernel\n%s  initrd\n%s  firmware\n%s  boot.iso\n",
+				kernelHash, initrdHash, m.FirmwareSHA256, m.ISOSHA256)
+			return
 		}
 
-		_, _ = fmt.Fprintf(w, "%s  kernel\n%s  initrd\n%s  firmware\n%s  boot.iso\n",
-			kernelHash, initrdHash, m.FirmwareSHA256, m.ISOSHA256)
+		http.NotFound(w, r)
 	})
 
 	m.Server = httptest.NewTLSServer(mux)
@@ -154,6 +169,32 @@ func (m *mockHTTPServer) GetInitrdDownloads() int {
 	defer m.mu.RUnlock()
 	return m.initrdDownloads
 }
+func (m *mockHTTPServer) GetFirmwareDownloads() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.firmwareDownloads
+}
+func (m *mockHTTPServer) GetISODownloads() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.isoDownloads
+}
+func (m *mockHTTPServer) SetFailInitrd(f bool)   { m.mu.Lock(); m.failInitrd = f; m.mu.Unlock() }
+func (m *mockHTTPServer) SetFailFirmware(f bool) { m.mu.Lock(); m.failFirmware = f; m.mu.Unlock() }
+func (m *mockHTTPServer) SetFailISO(f bool)      { m.mu.Lock(); m.failISO = f; m.mu.Unlock() }
+func (m *mockHTTPServer) SetChecksumResponse(path, content string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.checksumResponses == nil {
+		m.checksumResponses = make(map[string]string)
+	}
+	m.checksumResponses[path] = content
+}
+func (m *mockHTTPServer) ClearChecksumResponses() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.checksumResponses = nil
+}
 
 func (m *mockHTTPServer) ResetDownloadCounts() {
 	m.mu.Lock()
@@ -173,6 +214,30 @@ func (m *mockHTTPServer) directSpec() isobootv1alpha1.BootSourceSpec {
 func (m *mockHTTPServer) directSpecWithFirmware() isobootv1alpha1.BootSourceSpec {
 	spec := m.directSpec()
 	spec.Firmware = &isobootv1alpha1.DownloadableResource{URL: m.URL("/firmware"), Shasum: ptr.To(m.FirmwareSHA256)}
+	return spec
+}
+
+// isoSpec returns an ISO spec with inline shasum.
+func (m *mockHTTPServer) isoSpec() isobootv1alpha1.BootSourceSpec {
+	return isobootv1alpha1.BootSourceSpec{
+		ISO: &isobootv1alpha1.ISOSource{
+			DownloadableResource: isobootv1alpha1.DownloadableResource{
+				URL:    m.URL("/boot.iso"),
+				Shasum: ptr.To(m.ISOSHA256),
+			},
+			KernelPath: "/linux",
+			InitrdPath: "/initrd.gz",
+		},
+	}
+}
+
+// isoSpecWithFirmware returns an ISO spec with firmware.
+func (m *mockHTTPServer) isoSpecWithFirmware() isobootv1alpha1.BootSourceSpec {
+	spec := m.isoSpec()
+	spec.Firmware = &isobootv1alpha1.DownloadableResource{
+		URL:    m.URL("/firmware"),
+		Shasum: ptr.To(m.FirmwareSHA256),
+	}
 	return spec
 }
 
@@ -433,7 +498,6 @@ var _ = Describe("BootSource Integration", func() {
 			_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 
-			bs.Spec.Kernel.Shasum = ptr.To("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 			Expect(k8sClient.Get(ctx, key, bs)).To(Succeed())
 			bs.Spec.Kernel.Shasum = ptr.To("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 			Expect(k8sClient.Update(ctx, bs)).To(Succeed())
@@ -446,6 +510,337 @@ var _ = Describe("BootSource Integration", func() {
 
 			Expect(k8sClient.Get(ctx, key, bs)).To(Succeed())
 			Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseCorrupted))
+		})
+	})
+
+	// ── shasumURL Resolution Edge Cases ──────────────────────────────────
+
+	// checksumContentFn type for generating checksum content at test time
+	type checksumContentFn func(m *mockHTTPServer) string
+
+	DescribeTable("shasumURL resolution edge cases",
+		func(name string, checksumPath string, contentFn checksumContentFn, expectSuccess bool) {
+			checksumContent := contentFn(mockServer)
+			mockServer.SetChecksumResponse(checksumPath, checksumContent)
+			DeferCleanup(func() { mockServer.ClearChecksumResponses() })
+
+			spec := isobootv1alpha1.BootSourceSpec{
+				Kernel: &isobootv1alpha1.DownloadableResource{
+					URL:       mockServer.URL("/kernel"),
+					ShasumURL: ptr.To(mockServer.URL(checksumPath)),
+				},
+				Initrd: &isobootv1alpha1.DownloadableResource{
+					URL:       mockServer.URL("/initrd"),
+					ShasumURL: ptr.To(mockServer.URL(checksumPath)),
+				},
+			}
+
+			Expect(createBootSource(ctx, name, spec)).To(Succeed())
+			DeferCleanup(func() { deleteBootSource(ctx, name) })
+
+			key := types.NamespacedName{Name: name, Namespace: "default"}
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+
+			var bs isobootv1alpha1.BootSource
+			Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+
+			if expectSuccess {
+				Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseReady))
+			} else {
+				Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseFailed))
+			}
+		},
+		Entry("hash-first format (standard)", "int-shasum-hash-first", "/SHASUMS-hash-first",
+			checksumContentFn(func(m *mockHTTPServer) string {
+				return fmt.Sprintf("%s  kernel\n%s  initrd\n", m.KernelSHA256, m.InitrdSHA256)
+			}), true),
+		Entry("filename-first format", "int-shasum-filename-first", "/SHASUMS-filename-first",
+			checksumContentFn(func(m *mockHTTPServer) string {
+				return fmt.Sprintf("kernel  %s\ninitrd  %s\n", m.KernelSHA256, m.InitrdSHA256)
+			}), true),
+		Entry("relative path with ./prefix", "int-shasum-relative", "/SHASUMS-relative",
+			checksumContentFn(func(m *mockHTTPServer) string {
+				return fmt.Sprintf("%s  ./kernel\n%s  ./initrd\n", m.KernelSHA256, m.InitrdSHA256)
+			}), true),
+		Entry("CRLF line endings (Windows-style)", "int-shasum-crlf", "/SHASUMS-crlf",
+			checksumContentFn(func(m *mockHTTPServer) string {
+				// Uses CRLF line endings to ensure checksum parsing works with Windows-style files
+				return fmt.Sprintf("%s  kernel\r\n%s  initrd\r\n", m.KernelSHA256, m.InitrdSHA256)
+			}), true),
+		// Note: "longest suffix fallback" is tested in checksum unit tests;
+		// it requires multi-component file URLs which the mock server doesn't use.
+		Entry("ambiguous suffix (should fail)", "int-shasum-ambiguous", "/SHASUMS-ambiguous",
+			checksumContentFn(func(m *mockHTTPServer) string {
+				// Two entries match the suffix "kernel"
+				return fmt.Sprintf("%s  path1/kernel\n%s  path2/kernel\n%s  initrd\n",
+					m.KernelSHA256, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", m.InitrdSHA256)
+			}), false),
+		Entry("SHA512 algorithm (128-char hash)", "int-shasum-sha512", "/SHA512SUMS",
+			checksumContentFn(func(m *mockHTTPServer) string {
+				return fmt.Sprintf("%s  kernel\n%s  initrd\n", sha512sum(m.KernelContent), sha512sum(m.InitrdContent))
+			}), true),
+	)
+
+	// ── Multi-delete Recovery ────────────────────────────────────────────
+
+	Describe("Multi-delete recovery", func() {
+		Context("Direct mode", func() {
+			It("should recover when initrd + initrdWithFirmware both deleted", func() {
+				name := "int-multi-delete-direct-2"
+				reconcileToReady(name, mockServer.directSpecWithFirmware())
+
+				// Delete both initrd and initrdWithFirmware
+				initrdPath := filepath.Join(tempDir, "default", name, "initrd")
+				combinedPath := filepath.Join(tempDir, "default", name, "initrdWithFirmware")
+				Expect(os.Remove(initrdPath)).To(Succeed())
+				Expect(os.Remove(combinedPath)).To(Succeed())
+
+				mockServer.ResetDownloadCounts()
+
+				key := types.NamespacedName{Name: name, Namespace: "default"}
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).NotTo(HaveOccurred())
+
+				var bs isobootv1alpha1.BootSource
+				Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+				Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseReady))
+
+				// Verify files were restored
+				Expect(initrdPath).To(BeAnExistingFile())
+				Expect(combinedPath).To(BeAnExistingFile())
+				Expect(mockServer.GetInitrdDownloads()).To(Equal(1))
+			})
+
+			It("should recover when all three deleted (initrd + firmware + derived)", func() {
+				name := "int-multi-delete-direct-3"
+				reconcileToReady(name, mockServer.directSpecWithFirmware())
+
+				// Delete initrd, firmware, and initrdWithFirmware
+				initrdPath := filepath.Join(tempDir, "default", name, "initrd")
+				firmwarePath := filepath.Join(tempDir, "default", name, "firmware")
+				combinedPath := filepath.Join(tempDir, "default", name, "initrdWithFirmware")
+				Expect(os.Remove(initrdPath)).To(Succeed())
+				Expect(os.Remove(firmwarePath)).To(Succeed())
+				Expect(os.Remove(combinedPath)).To(Succeed())
+
+				mockServer.ResetDownloadCounts()
+
+				key := types.NamespacedName{Name: name, Namespace: "default"}
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).NotTo(HaveOccurred())
+
+				var bs isobootv1alpha1.BootSource
+				Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+				Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseReady))
+
+				// Verify all files restored
+				Expect(initrdPath).To(BeAnExistingFile())
+				Expect(firmwarePath).To(BeAnExistingFile())
+				Expect(combinedPath).To(BeAnExistingFile())
+				Expect(mockServer.GetInitrdDownloads()).To(Equal(1))
+				Expect(mockServer.GetFirmwareDownloads()).To(Equal(1))
+			})
+
+			It("should fail derived when source download fails during recovery", func() {
+				name := "int-multi-delete-fail-recovery"
+				reconcileToReady(name, mockServer.directSpecWithFirmware())
+
+				// Delete initrd and initrdWithFirmware
+				initrdPath := filepath.Join(tempDir, "default", name, "initrd")
+				combinedPath := filepath.Join(tempDir, "default", name, "initrdWithFirmware")
+				Expect(os.Remove(initrdPath)).To(Succeed())
+				Expect(os.Remove(combinedPath)).To(Succeed())
+
+				// Make initrd download fail
+				mockServer.SetFailInitrd(true)
+				mockServer.ResetDownloadCounts()
+
+				key := types.NamespacedName{Name: name, Namespace: "default"}
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).NotTo(HaveOccurred())
+
+				var bs isobootv1alpha1.BootSource
+				Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+				Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseFailed))
+			})
+		})
+
+		Context("ISO mode", func() {
+			It("should recover when extracted initrd + derived both deleted", func() {
+				name := "int-multi-delete-iso-2"
+				reconcileToReady(name, mockServer.isoSpecWithFirmware())
+
+				// Delete extracted initrd and initrdWithFirmware
+				initrdPath := filepath.Join(tempDir, "default", name, "initrd")
+				combinedPath := filepath.Join(tempDir, "default", name, "initrdWithFirmware")
+				Expect(os.Remove(initrdPath)).To(Succeed())
+				Expect(os.Remove(combinedPath)).To(Succeed())
+
+				mockServer.ResetDownloadCounts()
+
+				key := types.NamespacedName{Name: name, Namespace: "default"}
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).NotTo(HaveOccurred())
+
+				var bs isobootv1alpha1.BootSource
+				Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+				Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseReady))
+
+				// Verify files restored
+				Expect(initrdPath).To(BeAnExistingFile())
+				Expect(combinedPath).To(BeAnExistingFile())
+				// ISO should not be re-downloaded (still exists)
+				Expect(mockServer.GetISODownloads()).To(Equal(0))
+			})
+
+			It("should full-recover when ISO + firmware + derived all deleted", func() {
+				name := "int-multi-delete-iso-full"
+				reconcileToReady(name, mockServer.isoSpecWithFirmware())
+
+				// Delete everything
+				isoPath := filepath.Join(tempDir, "default", name, "iso")
+				kernelPath := filepath.Join(tempDir, "default", name, "kernel")
+				initrdPath := filepath.Join(tempDir, "default", name, "initrd")
+				firmwarePath := filepath.Join(tempDir, "default", name, "firmware")
+				combinedPath := filepath.Join(tempDir, "default", name, "initrdWithFirmware")
+				Expect(os.Remove(isoPath)).To(Succeed())
+				Expect(os.Remove(kernelPath)).To(Succeed())
+				Expect(os.Remove(initrdPath)).To(Succeed())
+				Expect(os.Remove(firmwarePath)).To(Succeed())
+				Expect(os.Remove(combinedPath)).To(Succeed())
+
+				mockServer.ResetDownloadCounts()
+
+				key := types.NamespacedName{Name: name, Namespace: "default"}
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).NotTo(HaveOccurred())
+
+				var bs isobootv1alpha1.BootSource
+				Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+				Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseReady))
+
+				// Verify all files restored
+				Expect(isoPath).To(BeAnExistingFile())
+				Expect(kernelPath).To(BeAnExistingFile())
+				Expect(initrdPath).To(BeAnExistingFile())
+				Expect(firmwarePath).To(BeAnExistingFile())
+				Expect(combinedPath).To(BeAnExistingFile())
+
+				// ISO and firmware should be re-downloaded
+				Expect(mockServer.GetISODownloads()).To(Equal(1))
+				Expect(mockServer.GetFirmwareDownloads()).To(Equal(1))
+			})
+		})
+	})
+
+	// ── Idempotent Behavior ──────────────────────────────────────────────
+
+	Context("Idempotent behavior", func() {
+		It("should skip download when files pre-exist with correct hash", func() {
+			name := "int-idempotent-preexist"
+
+			// Pre-create directory and files before creating BootSource
+			resourceDir := filepath.Join(tempDir, "default", name)
+			Expect(os.MkdirAll(resourceDir, 0o755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(resourceDir, "kernel"), mockServer.KernelContent, 0o644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(resourceDir, "initrd"), mockServer.InitrdContent, 0o644)).To(Succeed())
+
+			mockServer.ResetDownloadCounts()
+
+			spec := mockServer.directSpec()
+			Expect(createBootSource(ctx, name, spec)).To(Succeed())
+			DeferCleanup(func() { deleteBootSource(ctx, name) })
+
+			key := types.NamespacedName{Name: name, Namespace: "default"}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			var bs isobootv1alpha1.BootSource
+			Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+			Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseReady))
+
+			// No downloads should have occurred
+			Expect(mockServer.GetKernelDownloads()).To(Equal(0))
+			Expect(mockServer.GetInitrdDownloads()).To(Equal(0))
+		})
+
+		It("should re-download when files pre-exist with wrong hash", func() {
+			name := "int-idempotent-wrong-hash"
+
+			// Pre-create directory and files with wrong content
+			resourceDir := filepath.Join(tempDir, "default", name)
+			Expect(os.MkdirAll(resourceDir, 0o755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(resourceDir, "kernel"), []byte("wrong content"), 0o644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(resourceDir, "initrd"), []byte("wrong content"), 0o644)).To(Succeed())
+
+			mockServer.ResetDownloadCounts()
+
+			spec := mockServer.directSpec()
+			Expect(createBootSource(ctx, name, spec)).To(Succeed())
+			DeferCleanup(func() { deleteBootSource(ctx, name) })
+
+			key := types.NamespacedName{Name: name, Namespace: "default"}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			var bs isobootv1alpha1.BootSource
+			Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+			Expect(bs.Status.Phase).To(Equal(isobootv1alpha1.BootSourcePhaseReady))
+
+			// Both files should have been re-downloaded
+			Expect(mockServer.GetKernelDownloads()).To(Equal(1))
+			Expect(mockServer.GetInitrdDownloads()).To(Equal(1))
+		})
+	})
+
+	// ── CR Deletion Cleanup ──────────────────────────────────────────────
+
+	Context("CR deletion cleanup", func() {
+		It("should remove resource directory on CR deletion", func() {
+			name := "int-deletion-cleanup"
+			reconcileToReady(name, mockServer.directSpec())
+
+			resourceDir := filepath.Join(tempDir, "default", name)
+			Expect(resourceDir).To(BeADirectory())
+
+			// Delete the CR (DeferCleanup from reconcileToReady handles this, but we need to verify)
+			key := types.NamespacedName{Name: name, Namespace: "default"}
+			var bs isobootv1alpha1.BootSource
+			Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, &bs)).To(Succeed())
+
+			// Reconcile to trigger cleanup
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Directory should be removed
+			Expect(resourceDir).NotTo(BeADirectory())
+		})
+
+		It("should handle already-removed directory gracefully", func() {
+			name := "int-deletion-already-removed"
+			reconcileToReady(name, mockServer.directSpec())
+
+			resourceDir := filepath.Join(tempDir, "default", name)
+
+			// Manually remove the directory first
+			Expect(os.RemoveAll(resourceDir)).To(Succeed())
+			Expect(resourceDir).NotTo(BeADirectory())
+
+			// Delete the CR
+			key := types.NamespacedName{Name: name, Namespace: "default"}
+			var bs isobootv1alpha1.BootSource
+			Expect(k8sClient.Get(ctx, key, &bs)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, &bs)).To(Succeed())
+
+			// Reconcile should not error even though directory is already gone
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Extends `bootsource_integration_test.go` with ~15 new test cases covering scenarios from issue #167
- Adds mock server extensions for configurable checksum endpoints and additional failure injection
- Adds `isoSpec()` and `isoSpecWithFirmware()` helper functions
- Fixes duplicate shasum assignment bug in spec change test

### New Test Coverage

| Category | Tests | Description |
|----------|-------|-------------|
| shasumURL resolution | 6 | hash-first, filename-first, ./prefix, CRLF line endings, ambiguous suffix (negative), SHA512 |
| Multi-delete recovery | 5 | Direct mode (2 files, 3 files, fail during recovery), ISO mode (2 files, full recovery) |
| Idempotent behavior | 2 | Skip download when correct, re-download when wrong hash |
| CR deletion cleanup | 2 | Directory removal, already-removed graceful handling |

### Mock Server Extensions

- `SetFailInitrd`, `SetFailFirmware`, `SetFailISO` methods
- `GetFirmwareDownloads`, `GetISODownloads` getters
- `SetChecksumResponse`/`ClearChecksumResponses` for custom checksum content

## Test plan

- [x] `make build` passes
- [x] `make test` passes (89 specs in controller package)
- [x] `make lint` passes (0 issues)

Supersedes #171 (rebased after #170 merged)

Closes #167

🤖 Generated with [Claude Code](https://claude.ai/code)