### PR TITLE
Add Helm chart with OCI publish workflow

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -1,0 +1,21 @@
+name: Publish Helm Chart
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v4.1.0
+      - run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          helm package charts/isoboot --version $VERSION --app-version $VERSION
+          helm push isoboot-${VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,15 @@
+name: Verify
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make verify

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 bin/
+cover.out
 
 # IDE/editor
 .devcontainer/

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,18 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	"$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+.PHONY: helm-sync
+helm-sync: manifests ## Sync CRDs to Helm chart.
+	cp config/crd/bases/*.yaml charts/isoboot/templates/crd.yaml
+
+.PHONY: verify
+verify: helm-sync ## Verify generated files are up to date.
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: generated files are out of date. Run 'make helm-sync' and commit the changes."; \
+		git diff; \
+		exit 1; \
+	fi
+
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/charts/isoboot/Chart.yaml
+++ b/charts/isoboot/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: isoboot
+version: 0.1.0
+appVersion: "0.0.1"
+description: ISOBoot Kubernetes operator

--- a/charts/isoboot/templates/crd.yaml
+++ b/charts/isoboot/templates/crd.yaml
@@ -1,0 +1,266 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: bootsources.isoboot.github.io
+spec:
+  group: isoboot.github.io
+  names:
+    kind: BootSource
+    listKind: BootSourceList
+    plural: bootsources
+    singular: bootsource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BootSource is the Schema for the bootsources API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BootSourceSpec defines the desired state of BootSource
+            properties:
+              firmware:
+                description: Firmware specifies the firmware binary source
+                properties:
+                  url:
+                    description: URL contains the download URLs for the firmware
+                    properties:
+                      binary:
+                        description: Binary is the URL to download the file from
+                        type: string
+                      shasum:
+                        description: Shasum is the URL to download the checksum file
+                          from
+                        type: string
+                    required:
+                    - binary
+                    - shasum
+                    type: object
+                    x-kubernetes-validations:
+                    - message: binary URL is required
+                      rule: size(self.binary) > 0
+                    - message: shasum URL is required
+                      rule: size(self.shasum) > 0
+                    - message: binary URL must use https
+                      rule: size(self.binary) == 0 || self.binary.startsWith('https://')
+                    - message: shasum URL must use https
+                      rule: size(self.shasum) == 0 || self.shasum.startsWith('https://')
+                    - message: binary and shasum URLs must be on the same server
+                      rule: size(self.binary) == 0 || size(self.shasum) == 0 || !self.binary.startsWith('https://')
+                        || !self.shasum.startsWith('https://') || self.binary.split('://')[1].split('/')[0]
+                        == self.shasum.split('://')[1].split('/')[0]
+                required:
+                - url
+                type: object
+              initrd:
+                description: Initrd specifies the initrd binary source
+                properties:
+                  url:
+                    description: URL contains the download URLs for the initrd
+                    properties:
+                      binary:
+                        description: Binary is the URL to download the file from
+                        type: string
+                      shasum:
+                        description: Shasum is the URL to download the checksum file
+                          from
+                        type: string
+                    required:
+                    - binary
+                    - shasum
+                    type: object
+                    x-kubernetes-validations:
+                    - message: binary URL is required
+                      rule: size(self.binary) > 0
+                    - message: shasum URL is required
+                      rule: size(self.shasum) > 0
+                    - message: binary URL must use https
+                      rule: size(self.binary) == 0 || self.binary.startsWith('https://')
+                    - message: shasum URL must use https
+                      rule: size(self.shasum) == 0 || self.shasum.startsWith('https://')
+                    - message: binary and shasum URLs must be on the same server
+                      rule: size(self.binary) == 0 || size(self.shasum) == 0 || !self.binary.startsWith('https://')
+                        || !self.shasum.startsWith('https://') || self.binary.split('://')[1].split('/')[0]
+                        == self.shasum.split('://')[1].split('/')[0]
+                required:
+                - url
+                type: object
+              iso:
+                description: ISO specifies an ISO image containing kernel and initrd
+                properties:
+                  path:
+                    description: Path contains the paths to kernel/initrd inside the
+                      ISO
+                    properties:
+                      initrd:
+                        description: Initrd is the path to the initrd inside the ISO
+                        type: string
+                      kernel:
+                        description: Kernel is the path to the kernel inside the ISO
+                        type: string
+                    required:
+                    - initrd
+                    - kernel
+                    type: object
+                  url:
+                    description: URL contains the download URLs for the ISO
+                    properties:
+                      binary:
+                        description: Binary is the URL to download the file from
+                        type: string
+                      shasum:
+                        description: Shasum is the URL to download the checksum file
+                          from
+                        type: string
+                    required:
+                    - binary
+                    - shasum
+                    type: object
+                    x-kubernetes-validations:
+                    - message: binary URL is required
+                      rule: size(self.binary) > 0
+                    - message: shasum URL is required
+                      rule: size(self.shasum) > 0
+                    - message: binary URL must use https
+                      rule: size(self.binary) == 0 || self.binary.startsWith('https://')
+                    - message: shasum URL must use https
+                      rule: size(self.shasum) == 0 || self.shasum.startsWith('https://')
+                    - message: binary and shasum URLs must be on the same server
+                      rule: size(self.binary) == 0 || size(self.shasum) == 0 || !self.binary.startsWith('https://')
+                        || !self.shasum.startsWith('https://') || self.binary.split('://')[1].split('/')[0]
+                        == self.shasum.split('://')[1].split('/')[0]
+                required:
+                - path
+                - url
+                type: object
+                x-kubernetes-validations:
+                - message: iso requires path.kernel to be specified
+                  rule: size(self.path.kernel) > 0
+                - message: iso requires path.initrd to be specified
+                  rule: size(self.path.initrd) > 0
+              kernel:
+                description: Kernel specifies the kernel binary source
+                properties:
+                  url:
+                    description: URL contains the download URLs for the kernel
+                    properties:
+                      binary:
+                        description: Binary is the URL to download the file from
+                        type: string
+                      shasum:
+                        description: Shasum is the URL to download the checksum file
+                          from
+                        type: string
+                    required:
+                    - binary
+                    - shasum
+                    type: object
+                    x-kubernetes-validations:
+                    - message: binary URL is required
+                      rule: size(self.binary) > 0
+                    - message: shasum URL is required
+                      rule: size(self.shasum) > 0
+                    - message: binary URL must use https
+                      rule: size(self.binary) == 0 || self.binary.startsWith('https://')
+                    - message: shasum URL must use https
+                      rule: size(self.shasum) == 0 || self.shasum.startsWith('https://')
+                    - message: binary and shasum URLs must be on the same server
+                      rule: size(self.binary) == 0 || size(self.shasum) == 0 || !self.binary.startsWith('https://')
+                        || !self.shasum.startsWith('https://') || self.binary.split('://')[1].split('/')[0]
+                        == self.shasum.split('://')[1].split('/')[0]
+                required:
+                - url
+                type: object
+            type: object
+            x-kubernetes-validations:
+            - message: must specify either (kernel and initrd) or iso
+              rule: (has(self.kernel) && has(self.initrd)) || has(self.iso)
+            - message: cannot specify both (kernel or initrd) and iso
+              rule: '!((has(self.kernel) || has(self.initrd)) && has(self.iso))'
+          status:
+            description: BootSourceStatus defines the observed state of BootSource
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/isoboot/values.yaml
+++ b/charts/isoboot/values.yaml
@@ -1,0 +1,1 @@
+# Default values for isoboot


### PR DESCRIPTION
## Summary
- Add minimal Helm chart with BootSource CRD
- Add GitHub Actions workflow to publish chart to ghcr.io on tag push
- Add CI verification to block PRs if CRD is out of sync (FluxCD pattern)

## Files Changed
| File | Purpose |
|------|---------|
| `.github/workflows/helm-publish.yaml` | Publish chart to OCI on tag push |
| `.github/workflows/verify.yaml` | CI check - blocks PR if `make helm-sync` wasn't run |
| `.gitignore` | Add `cover.out` |
| `Makefile` | Add `helm-sync` and `verify` targets |
| `charts/isoboot/Chart.yaml` | Helm chart metadata |
| `charts/isoboot/templates/crd.yaml` | BootSource CRD (synced from `config/crd/bases/`) |
| `charts/isoboot/values.yaml` | Empty placeholder for future config |

## How it works

**CRD sync (FluxCD pattern):**
1. `make manifests` generates CRD to `config/crd/bases/`
2. `make helm-sync` copies to `charts/isoboot/templates/crd.yaml`
3. CI runs `make verify` which fails if files are out of sync

**Publishing:**
1. Push tag `v0.1.0`
2. Workflow packages and pushes to `oci://ghcr.io/isoboot/isoboot:0.1.0`

## Usage
```bash
# After changing API types
make helm-sync
git add -A && git commit

# Publish
git tag v0.1.0 && git push origin v0.1.0

# Install anywhere
helm install isoboot oci://ghcr.io/isoboot/isoboot --version 0.1.0
```

## Test plan
- [ ] Verify CI check passes
- [ ] Merge PR
- [ ] Push tag and verify publish workflow succeeds
- [ ] Install chart from OCI registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)