### PR TITLE
Add Phase field and set Pending on new resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ Multi-group layout organizes APIs by group name (e.g., `batch`, `apps`). Check t
 
 ## Critical Rules
 
+### Git & Pull Requests
+- **No force push** - Repository rules block force pushes. Create new commits instead of amending.
+- **Update PR body after commits** - If a new commit changes the scope or content of the PR, update the PR description to accurately reflect all changes.
+
 ### Never Edit These (Auto-Generated)
 - `config/crd/bases/*.yaml` - from `make manifests`
 - `config/rbac/role.yaml` - from `make manifests`

--- a/api/v1alpha1/bootsource_types.go
+++ b/api/v1alpha1/bootsource_types.go
@@ -87,8 +87,34 @@ type BootSourceSpec struct {
 	ISO *ISOSource `json:"iso,omitempty"`
 }
 
+// BootSourcePhase represents the current phase of a BootSource
+// +kubebuilder:validation:Enum=Pending;Downloading;Verifying;Extracting;Building;Ready;Failed;Corrupted
+type BootSourcePhase string
+
+const (
+	// PhasePending indicates the BootSource is waiting to be processed
+	PhasePending BootSourcePhase = "Pending"
+	// PhaseDownloading indicates the BootSource is downloading files
+	PhaseDownloading BootSourcePhase = "Downloading"
+	// PhaseVerifying indicates the BootSource is verifying checksums
+	PhaseVerifying BootSourcePhase = "Verifying"
+	// PhaseExtracting indicates the BootSource is extracting files from ISO
+	PhaseExtracting BootSourcePhase = "Extracting"
+	// PhaseBuilding indicates the BootSource is building artifacts
+	PhaseBuilding BootSourcePhase = "Building"
+	// PhaseReady indicates the BootSource is ready for use
+	PhaseReady BootSourcePhase = "Ready"
+	// PhaseFailed indicates the BootSource processing failed
+	PhaseFailed BootSourcePhase = "Failed"
+	// PhaseCorrupted indicates the BootSource checksum verification failed
+	PhaseCorrupted BootSourcePhase = "Corrupted"
+)
+
 // BootSourceStatus defines the observed state of BootSource
 type BootSourceStatus struct {
+	// Phase represents the current phase of the BootSource
+	// +optional
+	Phase BootSourcePhase `json:"phase,omitempty"`
 	// Conditions represent the latest available observations of an object's state
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -96,6 +122,8 @@ type BootSourceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // BootSource is the Schema for the bootsources API
 type BootSource struct {

--- a/charts/isoboot/templates/crd.yaml
+++ b/charts/isoboot/templates/crd.yaml
@@ -14,7 +14,14 @@ spec:
     singular: bootsource
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: BootSource is the Schema for the bootsources API
@@ -258,6 +265,18 @@ spec:
                   - type
                   type: object
                 type: array
+              phase:
+                description: Phase represents the current phase of the BootSource
+                enum:
+                - Pending
+                - Downloading
+                - Verifying
+                - Extracting
+                - Building
+                - Ready
+                - Failed
+                - Corrupted
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/isoboot.github.io_bootsources.yaml
+++ b/config/crd/bases/isoboot.github.io_bootsources.yaml
@@ -14,7 +14,14 @@ spec:
     singular: bootsource
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: BootSource is the Schema for the bootsources API
@@ -258,6 +265,18 @@ spec:
                   - type
                   type: object
                 type: array
+              phase:
+                description: Phase represents the current phase of the BootSource
+                enum:
+                - Pending
+                - Downloading
+                - Verifying
+                - Extracting
+                - Building
+                - Ready
+                - Failed
+                - Corrupted
+                type: string
             type: object
         type: object
     served: true

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	isobootv1alpha1 "github.com/isoboot/isoboot/api/v1alpha1"
+)
+
+// newTestBootSource creates a BootSource for testing with kernel+initrd
+func newTestBootSource(name, namespace string) *isobootv1alpha1.BootSource {
+	return &isobootv1alpha1.BootSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: isobootv1alpha1.BootSourceSpec{
+			Kernel: &isobootv1alpha1.KernelSource{
+				URL: isobootv1alpha1.URLSource{
+					Binary: "https://example.com/vmlinuz",
+					Shasum: "https://example.com/vmlinuz.sha256",
+				},
+			},
+			Initrd: &isobootv1alpha1.InitrdSource{
+				URL: isobootv1alpha1.URLSource{
+					Binary: "https://example.com/initrd.img",
+					Shasum: "https://example.com/initrd.img.sha256",
+				},
+			},
+		},
+	}
+}
+
+// newTestBootSourceISO creates a BootSource for testing with ISO
+func newTestBootSourceISO(name, namespace string) *isobootv1alpha1.BootSource {
+	return &isobootv1alpha1.BootSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: isobootv1alpha1.BootSourceSpec{
+			ISO: &isobootv1alpha1.ISOSource{
+				URL: isobootv1alpha1.URLSource{
+					Binary: "https://example.com/boot.iso",
+					Shasum: "https://example.com/boot.iso.sha256",
+				},
+				Path: isobootv1alpha1.PathSource{
+					Kernel: "/boot/vmlinuz",
+					Initrd: "/boot/initrd.img",
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Phase` field to BootSourceStatus with 8 lifecycle phases
- Controller sets phase to `Pending` on new resources
- Refactored tests with fake client for faster unit tests
- Added Git/PR rules to AGENTS.md

## Files Changed

| File | Why |
|------|-----|
| `AGENTS.md` | Added Git/PR rules (no force push, update PR body after commits). |
| `api/v1alpha1/bootsource_types.go` | Added `Phase` field and 8 phase constants. Added printcolumn for `kubectl get`. |
| `charts/isoboot/templates/crd.yaml` | Synced via `make helm-sync`. |
| `config/crd/bases/*.yaml` | Regenerated CRD with Phase field. |
| `internal/controller/bootsource_controller.go` | Fetch resource, set phase to Pending if empty, update status. |
| `internal/controller/bootsource_controller_test.go` | Refactored with fake client for unit tests + envtest for integration tests. |
| `internal/controller/testutil_test.go` | **New** - Helper functions to create test BootSource objects. |

## Test Structure

**Unit tests** (fake client - fast, no API server):
- `should set phase to Pending for new resources`
- `should not change phase if already set`
- `should handle not found resources gracefully`
- `should work with ISO-based BootSource`

**Integration tests** (envtest - real API server):
- `should reconcile successfully with real API server`

## Test plan
- [x] `make test` passes (coverage: 70.6%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)