### PR TITLE
Add CI workflow to build, scan, and push container images

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -5,8 +5,8 @@ on:
     branches: [main]
     tags: ['v*']
     paths:
-      - '**.go'
-      - '**.tmpl'
+      - '**/*.go'
+      - '**/*.tmpl'
       - '.dockerignore'
       - 'go.mod'
       - 'go.sum'
@@ -15,8 +15,8 @@ on:
       - '.github/workflows/docker-publish.yaml'
   pull_request:
     paths:
-      - '**.go'
-      - '**.tmpl'
+      - '**/*.go'
+      - '**/*.tmpl'
       - '.dockerignore'
       - 'go.mod'
       - 'go.sum'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/docker-publish.yaml` — a GitHub Actions workflow that builds, scans, and publishes both container images (`isoboot` and `isoboot-nginx`) to GHCR.

**Architecture:** Four jobs with least-privilege permissions:
- **build_isoboot** (read-only) — builds/scans `isoboot`; on `push`/`workflow_dispatch`, saves image tar + tags + SARIF as artifacts
- **build_isoboot_nginx** (read-only) — builds/scans `isoboot-nginx`; on `push`/`workflow_dispatch`, saves image tar + tags + SARIF as artifacts
- **push_isoboot** (`packages: write`, `security-events: write`) — pushes only `isoboot` artifacts
- **push_isoboot_nginx** (`packages: write`, `security-events: write`) — pushes only `isoboot-nginx` artifacts

Each push job depends only on its corresponding build job, so image publishing is independent per image.

**Triggers:** push to `main`, `v*` tags, pull requests, and manual `workflow_dispatch`.
Path filters include Go source, templates, Dockerfiles, `.dockerignore`, and the workflow file.

**Manual validation mode:** `workflow_dispatch` supports input `publish`:
- `publish: false` (default) loads and validates scanned images without pushing
- `publish: true` performs full GHCR publish from scanned artifacts

**Tags:** `sha-<short>`, `main` (branch), `pr-<num>` (PR), `<version>` and `<major>.<minor>` (semver on `v*` tags).

**Key design decisions:**
- Scan-before-push: Trivy runs before any publish to GHCR
- Same-image guarantee: push jobs load and push the exact scanned artifact image (no rebuild)
- Independent publishing: one image failure does not block the other image from publishing
- Strict artifact checks: successful build paths must provide `image.tar`, `tags.txt`, and `trivy-results.sarif`
- SARIF categories are unique per image (`trivy/isoboot`, `trivy/isoboot-nginx`)
- Concurrency control: workflow-level concurrency prevents overlapping runs on the same ref from racing tag updates
- Fork-safe: PR runs never receive write-capable token permissions
- `provenance: false` avoids attestation manifests on single-platform builds

## Test plan

- [x] Verify workflow triggers on this PR
- [x] Verify both build jobs complete on PR (`build_isoboot`, `build_isoboot_nginx`)
- [x] Verify Trivy scan runs for both images
- [x] Verify push jobs are skipped on PR events
- [ ] Run `workflow_dispatch` with `publish=false` and verify load/inspect validation path
- [ ] Run `workflow_dispatch` with `publish=true` and verify both images publish to GHCR from artifacts
- [ ] After merge to `main`, verify `main` and `sha-` tags are pushed
- [ ] On a `v*` tag push, verify semver tags (`<version>`, `<major>.<minor>`) are pushed

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
