### PR TITLE
Add subdirectory CLAUDE.md files

### DIFF
--- a/api/v1alpha1/CLAUDE.md
+++ b/api/v1alpha1/CLAUDE.md
@@ -1,0 +1,34 @@
+# api/v1alpha1
+
+CRD type definitions. After any change here, run `make manifests generate`.
+
+## Type Hierarchy
+
+```
+URL (string)                    # HTTPS-only, no @, MaxLength=2048
+  └─ BinaryHashPair             # binary + hash URLs, CEL hostname match
+       ├─ NetworkBootSpec.Kernel (direct boot)
+       ├─ NetworkBootSpec.Initrd (direct boot)
+       ├─ ISOSpec (embedded inline) + kernel/initrd paths
+       └─ FirmwareSpec (embedded inline) + prefix
+
+NetworkBootSpec                  # XOR: (kernel+initrd) or iso
+  ├─ Kernel *BinaryHashPair     # optional (required with initrd)
+  ├─ Initrd *BinaryHashPair     # optional (required with kernel)
+  ├─ ISO *ISOSpec               # optional (mutually exclusive with kernel/initrd)
+  └─ Firmware *FirmwareSpec     # optional (either mode)
+```
+
+## Validation Patterns Used
+
+- **Type-level markers** on `URL`: propagate to all fields of that type (MaxLength, Pattern)
+- **Struct-level CEL** on `BinaryHashPair`: `self.binary.split('/')[2] == self.hash.split('/')[2]` — propagates through `json:",inline"` embedding
+- **Spec-level CEL** on `NetworkBootSpec`: XOR via two rules (`has(self.kernel) == has(self.initrd)` and `has(self.iso) != has(self.kernel)`)
+- **Field-level CEL** for path traversal: `!self.contains('/../') && !self.endsWith('/..')`
+
+## Adding a New Field
+
+1. Add the field to the appropriate struct with json tag and kubebuilder markers
+2. Run `make manifests generate`
+3. Add positive and negative test entries in `internal/controller/networkboot_validation_test.go`
+4. Run `make test`

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -1,0 +1,19 @@
+# config
+
+Kubernetes manifests for CRD, RBAC, deployment, and kustomize overlays.
+
+## What Is Generated (DO NOT EDIT)
+
+- `crd/bases/*.yaml` — from `make manifests` (controller-gen reads markers in api/)
+- `rbac/role.yaml` — from `make manifests` (controller-gen reads RBAC markers in internal/controller/)
+
+## What Is Hand-Editable
+
+- `default/kustomization.yaml` — main kustomize overlay (namespace, patches)
+- `manager/manager.yaml` — controller deployment (resources, probes, security context)
+- `rbac/kustomization.yaml` — which RBAC files to include
+- `samples/*.yaml` — example CRs for users
+
+## Adding Labels to Generated Files
+
+Don't add labels directly to `rbac/role.yaml` — they'll be lost on `make manifests`. Instead use `commonLabels` in the relevant `kustomization.yaml`.

--- a/internal/controller/CLAUDE.md
+++ b/internal/controller/CLAUDE.md
@@ -1,0 +1,39 @@
+# internal/controller
+
+Controller reconciliation logic and integration tests.
+
+## Test Setup
+
+Tests use **envtest** (real K8s API server + etcd) via `suite_test.go`. The CRD is loaded from `config/crd/bases/`, so `make manifests` must have been run first. `make test` handles this automatically.
+
+Shared variables available across test files (same package):
+- `k8sClient` — controller-runtime client for creating/getting/deleting resources
+- `ctx`, `cancel` — context for the test suite
+- `cfg` — rest.Config for the envtest API server
+- `testEnv` — the envtest.Environment
+
+## Test Helpers (defined in networkboot_validation_test.go)
+
+```go
+pair(binary, hash URL) BinaryHashPair          // shorthand constructor
+directBootSpec(kernel, initrd BinaryHashPair)   // direct boot mode spec
+isoBootSpec(isoPair BinaryHashPair, kernel, initrd string)  // ISO boot mode spec
+withFirmware(spec, fwPair BinaryHashPair, prefix *string)   // adds firmware to any spec
+createNetworkBoot(name string, spec) error      // creates resource, returns error
+deleteNetworkBoot(name string)                  // best-effort cleanup
+ptr(s string) *string                           // pointer helper
+
+// Pre-built valid pairs:
+validPair     // https://example.com/artifact
+validFWPair   // https://fw.example.com/fw.bin
+validISOPair  // https://releases.ubuntu.com/noble.iso
+```
+
+## Adding a New Validation Test
+
+Use `DescribeTable`/`Entry` for table-driven tests. Negative tests don't need cleanup (resource was never created). Positive tests need `deleteNetworkBoot` in `AfterEach` or inline.
+
+```go
+Entry("description of what is being tested",
+    directBootSpec(pair("https://...", "https://..."), validPair)),
+```


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` to `api/v1alpha1/`, `internal/controller/`, and `config/`
- Subdirectory-level guidance for faster Claude Code onboarding

## What each file covers
- **api/v1alpha1**: type hierarchy diagram, validation marker patterns, how to add a new field
- **internal/controller**: envtest setup, shared test helpers with signatures, how to add new tests
- **config**: generated vs hand-editable files, how to add labels without losing them

🤖 Generated with [Claude Code](https://claude.com/claude-code)