### PR TITLE
Enable verbose Ginkgo test output in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test -v $$(go list ./... | grep -v /e2e | grep -v /internal/controller) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test -v ./internal/controller/... -ginkgo.v -coverprofile cover-controller.out
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.


### PR DESCRIPTION
## Summary
- Split the `make test` target to run controller tests separately with `-ginkgo.v` flag
- Individual test names (e.g. "URL validation", "should reject invalid URLs") are now visible in CI logs
- Non-Ginkgo packages continue to run with standard `-v` flag

## Test plan
- [x] `make test` passes locally — all 47 specs pass with verbose names shown
- [x] `make lint` passes
- [ ] CI Tests workflow shows individual test names in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)