### PR TITLE
Add Helm chart with HTTP server configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,19 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG}
 	"$(KUSTOMIZE)" build config/default > dist/install.yaml
 
+##@ Helm
+
+.PHONY: helm-sync
+helm-sync: manifests ## Sync generated CRD into the Helm chart.
+	cp config/crd/bases/boot.isoboot.github.io_networkboots.yaml charts/isoboot/templates/crd.yaml
+
+.PHONY: verify
+verify: helm-sync ## Verify that generated files are up to date.
+	@if [ -n "$$(git diff --name-only charts/isoboot/templates/crd.yaml)" ]; then \
+		echo "ERROR: Helm chart CRD is out of date. Run 'make helm-sync' and commit the result."; \
+		exit 1; \
+	fi
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/charts/isoboot/Chart.yaml
+++ b/charts/isoboot/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: isoboot
+description: Kubernetes operator for HTTP-based PXE network booting
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/isoboot/templates/_helpers.tpl
+++ b/charts/isoboot/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "isoboot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "isoboot.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "isoboot.labels" -}}
+app.kubernetes.io/name: {{ include "isoboot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+control-plane: controller-manager
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "isoboot.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "isoboot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+control-plane: controller-manager
+{{- end }}

--- a/charts/isoboot/templates/clusterrole.yaml
+++ b/charts/isoboot/templates/clusterrole.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "isoboot.fullname" . }}-manager-role
+  labels:
+    {{- include "isoboot.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - boot.isoboot.github.io
+  resources:
+  - networkboots
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - boot.isoboot.github.io
+  resources:
+  - networkboots/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - boot.isoboot.github.io
+  resources:
+  - networkboots/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/charts/isoboot/templates/clusterrolebinding.yaml
+++ b/charts/isoboot/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "isoboot.fullname" . }}-manager-rolebinding
+  labels:
+    {{- include "isoboot.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "isoboot.fullname" . }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "isoboot.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/isoboot/templates/crd.yaml
+++ b/charts/isoboot/templates/crd.yaml
@@ -1,0 +1,241 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: networkboots.boot.isoboot.github.io
+spec:
+  group: boot.isoboot.github.io
+  names:
+    kind: NetworkBoot
+    listKind: NetworkBootList
+    plural: networkboots
+    singular: networkboot
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetworkBoot is the Schema for the networkboots API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of NetworkBoot
+            properties:
+              firmware:
+                description: firmware defines firmware binary, hash, and optional
+                  path prefix.
+                properties:
+                  binary:
+                    description: binary is the HTTPS URL of the artifact.
+                    maxLength: 2048
+                    pattern: ^https://[^/@]+/[^/].*$
+                    type: string
+                  hash:
+                    description: hash is the HTTPS URL of the hash for the artifact.
+                    maxLength: 2048
+                    pattern: ^https://[^/@]+/[^/].*$
+                    type: string
+                  prefix:
+                    default: /with-firmware
+                    description: prefix is the path prefix for firmware serving.
+                    maxLength: 256
+                    pattern: ^/[^/](.*[^/])?$
+                    type: string
+                    x-kubernetes-validations:
+                    - message: must not contain path traversal
+                      rule: '!self.contains(''/../'') && !self.endsWith(''/..'')'
+                required:
+                - binary
+                - hash
+                type: object
+                x-kubernetes-validations:
+                - message: binary and hash hostnames must match
+                  rule: self.binary.split('/')[2] == self.hash.split('/')[2]
+              initrd:
+                description: initrd defines the initrd binary and hash URLs (direct
+                  boot mode).
+                properties:
+                  binary:
+                    description: binary is the HTTPS URL of the artifact.
+                    maxLength: 2048
+                    pattern: ^https://[^/@]+/[^/].*$
+                    type: string
+                  hash:
+                    description: hash is the HTTPS URL of the hash for the artifact.
+                    maxLength: 2048
+                    pattern: ^https://[^/@]+/[^/].*$
+                    type: string
+                required:
+                - binary
+                - hash
+                type: object
+                x-kubernetes-validations:
+                - message: binary and hash hostnames must match
+                  rule: self.binary.split('/')[2] == self.hash.split('/')[2]
+              iso:
+                description: iso defines an ISO image and paths to kernel/initrd within
+                  it (ISO boot mode).
+                properties:
+                  binary:
+                    description: binary is the HTTPS URL of the artifact.
+                    maxLength: 2048
+                    pattern: ^https://[^/@]+/[^/].*$
+                    type: string
+                  hash:
+                    description: hash is the HTTPS URL of the hash for the artifact.
+                    maxLength: 2048
+                    pattern: ^https://[^/@]+/[^/].*$
+                    type: string
+                  initrd:
+                    description: initrd is the absolute path to the initrd within
+                      the ISO.
+                    maxLength: 1024
+                    pattern: ^/.*$
+                    type: string
+                    x-kubernetes-validations:
+                    - message: must not contain path traversal
+                      rule: '!self.contains(''/../'') && !self.endsWith(''/..'')'
+                  kernel:
+                    description: kernel is the absolute path to the kernel within
+                      the ISO.
+                    maxLength: 1024
+                    pattern: ^/.*$
+                    type: string
+                    x-kubernetes-validations:
+                    - message: must not contain path traversal
+                      rule: '!self.contains(''/../'') && !self.endsWith(''/..'')'
+                required:
+                - binary
+                - hash
+                - initrd
+                - kernel
+                type: object
+                x-kubernetes-validations:
+                - message: binary and hash hostnames must match
+                  rule: self.binary.split('/')[2] == self.hash.split('/')[2]
+              kernel:
+                description: kernel defines the kernel binary and hash URLs (direct
+                  boot mode).
+                properties:
+                  binary:
+                    description: binary is the HTTPS URL of the artifact.
+                    maxLength: 2048
+                    pattern: ^https://[^/@]+/[^/].*$
+                    type: string
+                  hash:
+                    description: hash is the HTTPS URL of the hash for the artifact.
+                    maxLength: 2048
+                    pattern: ^https://[^/@]+/[^/].*$
+                    type: string
+                required:
+                - binary
+                - hash
+                type: object
+                x-kubernetes-validations:
+                - message: binary and hash hostnames must match
+                  rule: self.binary.split('/')[2] == self.hash.split('/')[2]
+            type: object
+            x-kubernetes-validations:
+            - message: kernel and initrd must both be set or both be unset
+              rule: has(self.kernel) == has(self.initrd)
+            - message: must specify either (kernel and initrd) or iso, not both and
+                not neither
+              rule: has(self.iso) != has(self.kernel)
+          status:
+            description: status defines the observed state of NetworkBoot
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the NetworkBoot resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/isoboot/templates/deployment.yaml
+++ b/charts/isoboot/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "isoboot.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "isoboot.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "isoboot.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        {{- include "isoboot.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: manager
+        command:
+        - /manager
+        args:
+        - --leader-elect={{ .Values.manager.leaderElect }}
+        - --health-probe-bind-address={{ .Values.manager.healthProbeBindAddress }}
+        - --metrics-bind-address={{ .Values.manager.metricsBindAddress }}
+        - --node-name={{ required "isoboot.http.nodeName is required" .Values.isoboot.http.nodeName }}
+        - --subnet-cidr={{ required "isoboot.http.cidr is required" .Values.isoboot.http.cidr }}
+        image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.manager.resources | nindent 10 }}
+      serviceAccountName: {{ include "isoboot.fullname" . }}-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/charts/isoboot/templates/metrics-service.yaml
+++ b/charts/isoboot/templates/metrics-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "isoboot.fullname" . }}-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "isoboot.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    {{- include "isoboot.selectorLabels" . | nindent 4 }}

--- a/charts/isoboot/templates/serviceaccount.yaml
+++ b/charts/isoboot/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "isoboot.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "isoboot.labels" . | nindent 4 }}

--- a/charts/isoboot/values.yaml
+++ b/charts/isoboot/values.yaml
@@ -1,0 +1,27 @@
+isoboot:
+  http:
+    # nodeName is the Kubernetes node where the HTTP file server runs.
+    # Required. The controller pins download Jobs and nginx to this node.
+    # Example: "node01"
+    nodeName: ""
+
+    # cidr is the subnet CIDR for the PXE network.
+    # Required. The controller resolves the node's IP within this subnet.
+    # Example: "192.168.88.0/24"
+    cidr: ""
+
+manager:
+  image:
+    repository: controller
+    tag: latest
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+
+  leaderElect: true
+  metricsBindAddress: ":8443"
+  healthProbeBindAddress: ":8081"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,6 +61,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var nodeName string
+	var subnetCIDR string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -79,6 +81,8 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.StringVar(&nodeName, "node-name", "", "Target node for file server and download Jobs")
+	flag.StringVar(&subnetCIDR, "subnet-cidr", "", "Subnet CIDR for resolving the node's PXE network IP")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -179,8 +183,10 @@ func main() {
 	}
 
 	if err := (&controller.NetworkBootReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		NodeName:   nodeName,
+		SubnetCIDR: subnetCIDR,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NetworkBoot")
 		os.Exit(1)

--- a/internal/controller/networkboot_controller.go
+++ b/internal/controller/networkboot_controller.go
@@ -30,7 +30,9 @@ import (
 // NetworkBootReconciler reconciles a NetworkBoot object
 type NetworkBootReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme     *runtime.Scheme
+	NodeName   string
+	SubnetCIDR string
 }
 
 // +kubebuilder:rbac:groups=boot.isoboot.github.io,resources=networkboots,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## Summary

- Create Helm chart at `charts/isoboot/` deploying the operator with CRD, RBAC, Deployment, ServiceAccount, and metrics Service
- Add two mandatory values (`isoboot.http.nodeName`, `isoboot.http.cidr`) validated with `required` — `helm install` fails with a clear error if either is missing
- Pass these values as `--node-name` and `--subnet-cidr` args to the controller manager container
- Add `NodeName` and `SubnetCIDR` fields to `NetworkBootReconciler` struct (reconciliation logic deferred to a later PR)
- Add `make helm-sync` and `make verify` Makefile targets to keep Helm chart CRD in sync with generated CRD

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (60/60 specs)
- [x] `helm template` with `--set isoboot.http.nodeName=node01 --set isoboot.http.cidr=192.168.88.0/24` renders correct YAML with args
- [x] `helm template` without required values fails: `isoboot.http.nodeName is required`
- [x] `make helm-sync && make verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)