### PR TITLE
Add verify-manifests CI check

### DIFF
--- a/.github/workflows/verify-manifests.yml
+++ b/.github/workflows/verify-manifests.yml
@@ -1,0 +1,28 @@
+name: Verify Manifests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  verify:
+    name: Generated files are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate manifests
+        run: make manifests generate
+
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Generated files are out of date. Run 'make manifests generate' and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Add CI workflow that runs `make manifests generate` and fails if generated files are out of date
- Ensures CRDs, RBAC, and deepcopy are always in sync with types

## Test plan
- [x] Workflow file is valid YAML
- [ ] CI run passes on this PR