### PR TITLE
Add E2E DHCP network test workflow

### DIFF
--- a/.github/workflows/test-e2e-dhcp.yml
+++ b/.github/workflows/test-e2e-dhcp.yml
@@ -88,7 +88,8 @@ jobs:
           --bind-interfaces \
           --dhcp-range=192.168.101.100,192.168.101.200,255.255.255.0,1h \
           --dhcp-option=option:router,192.168.101.1 \
-          --log-dhcp
+          --log-dhcp \
+          --log-facility=/tmp/dnsmasq.log
 
         # Wait for dnsmasq to be ready
         for i in 1 2 3 4 5; do
@@ -257,6 +258,8 @@ jobs:
         sudo ip netns exec ns-srv ip addr 2>/dev/null || true
         echo "=== Kind node (ns-kind) ==="
         sudo ip netns exec ns-kind ip addr 2>/dev/null || true
+        echo "=== dnsmasq DHCP logs ==="
+        docker exec dhcp-srv cat /tmp/dnsmasq.log 2>/dev/null || true
         echo "=== dnsmasq container logs ==="
         docker logs dhcp-srv 2>/dev/null || true
         echo "=== BootArtifact status ==="


### PR DESCRIPTION
## Summary
- Adds a **manual** (`workflow_dispatch`) GitHub Action that tests isoboot on an isolated 192.168.101.0/24 network using Linux network namespaces
- DHCP server: Alpine Docker container (`--network=none`) running dnsmasq at 192.168.101.1 (static), attached to a `br-pxe` bridge via veth
- DHCP client: Kind node container connected to the same bridge, gets its IP via DHCP lease from dnsmasq
- Deploys isoboot Helm chart into Kind, creates Rocky Linux 10.1 BootArtifacts + BootConfig, and verifies SHA-256 checksums and symlinks on host disk

## Test plan
- [ ] Trigger workflow manually from Actions tab
- [ ] Verify dnsmasq starts and hands out a DHCP lease to the Kind node
- [ ] Verify bidirectional ping between DHCP server container and Kind node on 192.168.101.0/24
- [ ] Verify Rocky Linux 10.1 kernel + initrd download to Ready phase
- [ ] Verify BootConfig symlinks resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)