### PR TITLE
Add tag release & E2E test workflow

### DIFF
--- a/.github/workflows/test-tag-helm-install.yaml
+++ b/.github/workflows/test-tag-helm-install.yaml
@@ -82,7 +82,7 @@ jobs:
         sed -i "s/^version:.*/version: ${VERSION}/" charts/isoboot/Chart.yaml
         sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/isoboot/Chart.yaml
         helm package charts/isoboot --destination /tmp/charts
-        helm push /tmp/charts/isoboot-${VERSION}.tgz oci://${{ env.REGISTRY }}/isoboot/charts
+        helm push /tmp/charts/isoboot-${VERSION}.tgz oci://${REGISTRY}/isoboot/charts
 
     # ── PXE network: Docker dnsmasq at .1, Kind=DHCP client ─────────
     # The DHCP network is tested alongside isoboot as groundwork for
@@ -207,7 +207,7 @@ jobs:
         VERSION: ${{ steps.version.outputs.version }}
         NODE_NAME: ${{ steps.node.outputs.name }}
       run: |
-        helm install isoboot oci://${{ env.REGISTRY }}/isoboot/charts/isoboot \
+        helm install isoboot oci://${REGISTRY}/isoboot/charts/isoboot \
           --version "${VERSION}" \
           --namespace isoboot-system \
           --create-namespace \


### PR DESCRIPTION
## Summary
- Rename `test-e2e-dhcp.yml` to `test-tag-helm-install.yaml` and repurpose as a tag-triggered release + E2E test workflow
- On tag push (`v*`): build & push multi-arch (amd64/arm64) container image to GHCR, package & push Helm chart as OCI artifact to GHCR
- E2E test installs from GHCR (both chart and image) instead of local builds — validates the actual release artifacts
- Also supports `workflow_dispatch` with a version input for manual testing

## Test plan
- [ ] Push a test tag (`v0.0.1-rc1`) to trigger the workflow
- [ ] Verify multi-arch image is pushed to `ghcr.io/isoboot/isoboot`
- [ ] Verify Helm chart is pushed to `oci://ghcr.io/isoboot/charts/isoboot`
- [ ] Verify `helm install` from GHCR succeeds and controller pod starts
- [ ] Verify full E2E (BootArtifacts, BootConfig, PXE network) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)