### PR TITLE
Add CHANGELOG.md with v0.0.1-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Controller manager can download basic boot artifacts
 - Controller manager can create basic boot configs
+- Tested: https://github.com/isoboot/isoboot/actions/runs/22932882510


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md documenting the v0.0.1-rc1 release
- Controller manager can download basic boot artifacts and create basic boot configs
- Tested with https://github.com/isoboot/isoboot/actions/runs/22932882510

## Test plan
- [X] Verify CHANGELOG.md content is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)