### PR TITLE
Add pod anti-affinity to controller manager

### DIFF
--- a/charts/isoboot/templates/deployment.yaml
+++ b/charts/isoboot/templates/deployment.yaml
@@ -24,8 +24,15 @@ spec:
     spec:
       serviceAccountName: {{ include "isoboot.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
-      nodeName: {{ .Values.nodeName }}
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchFields:
+              - key: metadata.name
+                operator: In
+                values:
+                - {{ .Values.nodeName }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:


### PR DESCRIPTION
Closes #273

## Summary
- Add `app.kubernetes.io/component: controller` label to controller deployment selector and pod template
- Replace `nodeName` with `nodeAffinity` using `matchFields` on `metadata.name` so the scheduler is involved
- Add `podAntiAffinity` with `requiredDuringSchedulingIgnoredDuringExecution` on `kubernetes.io/hostname` to prevent 2 controller replicas on the same node

Note: The selector change means existing deployments must be recreated on upgrade (selectors are immutable). Acceptable for a pre-release project.

## Test plan
- [x] Verify `helm install` succeeds with the new selector
- [x] Verify controller pod starts and is Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)