### PR TITLE
Add Helm quoting rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,10 @@
 - Commit messages must be 40 characters or fewer.
 - Always add `Co-Authored-By: Claude Code <noreply@anthropic.com>` to commit messages.
 
+## Helm Templates
+
+- Quote interpolated values: use `{{ .Values.foo | quote }}` for YAML fields, `"{{ .Values.foo }}"` for inline shell args.
+
 ## E2E Tests
 
 - Don't use loops to verify downloads — just duplicate the check per artifact (max 3). A little duplication is clearer than loop + if/else mapping.


### PR DESCRIPTION
## Summary
- Add Helm template quoting convention to CLAUDE.md: `| quote` for YAML fields, double quotes for inline shell args

Closes #284

## Test plan
- [ ] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)