### PR TITLE
Quote Helm template values

### DIFF
--- a/charts/isoboot/templates/deployment.yaml
+++ b/charts/isoboot/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               - key: metadata.name
                 operator: In
                 values:
-                - {{ .Values.nodeName }}
+                - {{ .Values.nodeName | quote }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -51,9 +51,9 @@ spec:
         args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8443
-        - --data-dir={{ .Values.dataDir }}
+        - "--data-dir={{ .Values.dataDir }}"
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
@@ -76,9 +76,9 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:
         - name: data
-          mountPath: {{ .Values.dataDir }}
+          mountPath: {{ .Values.dataDir | quote }}
       volumes:
       - name: data
         hostPath:
-          path: {{ .Values.dataDir }}
+          path: {{ .Values.dataDir | quote }}
           type: Directory

--- a/charts/isoboot/templates/dnsmasq-deployment.yaml
+++ b/charts/isoboot/templates/dnsmasq-deployment.yaml
@@ -37,7 +37,7 @@ spec:
               - key: metadata.name
                 operator: In
                 values:
-                - {{ .Values.nodeName }}
+                - {{ .Values.nodeName | quote }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -47,7 +47,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       initContainers:
       - name: extract-ipxe
-        image: {{ .Values.dnsmasq.image.repository }}:{{ .Values.dnsmasq.image.tag | default .Chart.AppVersion }}
+        image: "{{ .Values.dnsmasq.image.repository }}:{{ .Values.dnsmasq.image.tag | default .Chart.AppVersion }}"
         command: ["/bin/sh", "-c"]
         args:
         - |
@@ -61,13 +61,13 @@ spec:
           ls -la "$DEST"
         volumeMounts:
         - name: data
-          mountPath: {{ .Values.dataDir }}
+          mountPath: {{ .Values.dataDir | quote }}
           readOnly: true
         - name: ipxe
           mountPath: /ipxe
       containers:
       - name: dnsmasq
-        image: {{ .Values.dnsmasq.image.repository }}:{{ .Values.dnsmasq.image.tag | default .Chart.AppVersion }}
+        image: "{{ .Values.dnsmasq.image.repository }}:{{ .Values.dnsmasq.image.tag | default .Chart.AppVersion }}"
         command: ["/bin/sh", "-c"]
         args:
         - |
@@ -134,7 +134,7 @@ spec:
       volumes:
       - name: data
         hostPath:
-          path: {{ .Values.dataDir }}
+          path: {{ .Values.dataDir | quote }}
           type: Directory
       - name: ipxe
         emptyDir: {}

--- a/charts/isoboot/templates/nginx-configmap.yaml
+++ b/charts/isoboot/templates/nginx-configmap.yaml
@@ -18,7 +18,7 @@ data:
         server {
             listen {{ .Values.nginx.port }};
             location /static/ {
-                alias {{ .Values.dataDir }}/boot/;
+                alias "{{ .Values.dataDir }}/boot/";
             }
         }
     }

--- a/charts/isoboot/templates/nginx-deployment.yaml
+++ b/charts/isoboot/templates/nginx-deployment.yaml
@@ -30,7 +30,7 @@ spec:
               - key: metadata.name
                 operator: In
                 values:
-                - {{ .Values.nodeName }}
+                - {{ .Values.nodeName | quote }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -71,7 +71,7 @@ spec:
           subPath: nginx.conf
           readOnly: true
         - name: data
-          mountPath: {{ .Values.dataDir }}
+          mountPath: {{ .Values.dataDir | quote }}
           readOnly: true
         - name: cache
           mountPath: /var/cache/nginx
@@ -83,7 +83,7 @@ spec:
           name: {{ include "isoboot.fullname" . }}-nginx-config
       - name: data
         hostPath:
-          path: {{ .Values.dataDir }}
+          path: {{ .Values.dataDir | quote }}
           type: Directory
       - name: cache
         emptyDir: {}


### PR DESCRIPTION
## Summary
- Add `| quote` to YAML string fields (`nodeName`, `dataDir`, `imagePullPolicy`) across deployment, nginx, dnsmasq, and configmap templates
- Wrap `image:` values and shell args (`--data-dir`, nginx `alias`) in double quotes
- Numeric fields (ports) left unquoted as they are integer values

Closes #283

## Test plan
- [x] `make lint` passes (includes `helm lint`)
- [x] `make test` passes
- [x] `helm template` renders quoted values correctly (e.g. `mountPath: "/data/isoboot"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)