### PR TITLE
Add v0.0.1-rc2 to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.0.1-rc2
+
+- Add nginx PXE file server to Helm chart
+- Add E2E download test for PXE file serving
+- Add pod anti-affinity to controller manager
+- Add tag release and E2E test workflow
+
 ## v0.0.1-rc1
 
 - Controller manager can download basic boot artifacts


### PR DESCRIPTION
## Summary
- Add v0.0.1-rc2 changelog entry covering nginx PXE file server, E2E test, pod anti-affinity, and tag release workflow

## Test plan
- [ ] Verify CHANGELOG.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)