### PR TITLE
Add iPXE sanboot fallback on chain fail

### DIFF
--- a/charts/isoboot/templates/dnsmasq-deployment.yaml
+++ b/charts/isoboot/templates/dnsmasq-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           echo -n "$HOST_IP" > /config/host-ip
           echo -n "$IFACE" > /config/iface
           mkdir -p "{{ .Values.dataDir }}/boot" || { echo "FAIL: cannot create {{ .Values.dataDir }}/boot — ensure dataDir is writable by UID 65532"; exit 1; }
-          printf '#!ipxe\nchain http://%s:{{ .Values.nginx.port }}/dynamic/conditional-boot?mac=${net0/mac}\n' "$HOST_IP" > "{{ .Values.dataDir }}/boot/boot.ipxe"
+          printf '#!ipxe\nchain http://%s:{{ .Values.nginx.port }}/dynamic/conditional-boot?mac=${net0/mac} || sanboot --no-describe --drive 0x80\n' "$HOST_IP" > "{{ .Values.dataDir }}/boot/boot.ipxe"
           echo "Generated boot.ipxe:"
           cat "{{ .Values.dataDir }}/boot/boot.ipxe"
         securityContext:


### PR DESCRIPTION
## Summary
- Add `|| sanboot --no-describe --drive 0x80` to the iPXE chain command in boot.ipxe so machines fall back to local disk boot when the conditional-boot chain fails

## Test plan
- [ ] Verify boot.ipxe contains the `|| sanboot` fallback after deploy
- [ ] Test that a machine with no BootConfig boots from local disk instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)