### PR TITLE
Namespace dataDir by component

### DIFF
--- a/charts/isoboot/templates/deployment.yaml
+++ b/charts/isoboot/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8443
-        - "--data-dir={{ .Values.dataDir }}"
+        - "--data-dir={{ .Values.dataDir }}/nginx/static"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         securityContext:

--- a/charts/isoboot/templates/dnsmasq-deployment.yaml
+++ b/charts/isoboot/templates/dnsmasq-deployment.yaml
@@ -52,10 +52,10 @@ spec:
           echo "Detected interface=$IFACE host_ip=$HOST_IP"
           echo -n "$HOST_IP" > /config/host-ip
           echo -n "$IFACE" > /config/iface
-          mkdir -p "{{ .Values.dataDir }}/boot" || { echo "FAIL: cannot create {{ .Values.dataDir }}/boot — ensure dataDir is writable by UID 65532"; exit 1; }
-          printf '#!ipxe\nchain http://%s:{{ .Values.nginx.port }}/dynamic/conditional-boot?mac=${net0/mac:hexhyp} || sanboot --no-describe --drive 0x80\n' "$HOST_IP" > "{{ .Values.dataDir }}/boot/boot.ipxe"
+          mkdir -p "{{ .Values.dataDir }}/nginx/static/boot" || { echo "FAIL: cannot create {{ .Values.dataDir }}/nginx/static/boot — ensure dataDir is writable by UID 65532"; exit 1; }
+          printf '#!ipxe\nchain http://%s:{{ .Values.nginx.port }}/dynamic/conditional-boot?mac=${net0/mac:hexhyp} || sanboot --no-describe --drive 0x80\n' "$HOST_IP" > "{{ .Values.dataDir }}/nginx/static/boot/boot.ipxe"
           echo "Generated boot.ipxe:"
-          cat "{{ .Values.dataDir }}/boot/boot.ipxe"
+          cat "{{ .Values.dataDir }}/nginx/static/boot/boot.ipxe"
         securityContext:
           runAsUser: 65532
           runAsNonRoot: true
@@ -75,7 +75,7 @@ spec:
         args:
         - |
           set -e
-          TARBALL="{{ .Values.dataDir }}/artifacts/{{ include "isoboot.fullname" . }}-ipxe/ipxeboot.tar.gz"
+          TARBALL="{{ .Values.dataDir }}/nginx/static/artifacts/{{ include "isoboot.fullname" . }}-ipxe/ipxeboot.tar.gz"
           DEST="/ipxe"
           echo "Waiting for iPXE tarball at $TARBALL (timeout 300s)..."
           ELAPSED=0

--- a/charts/isoboot/templates/nginx-configmap.yaml
+++ b/charts/isoboot/templates/nginx-configmap.yaml
@@ -18,7 +18,7 @@ data:
         server {
             listen {{ .Values.nginx.port }};
             location /static/ {
-                alias "{{ .Values.dataDir }}/boot/";
+                alias "{{ .Values.dataDir }}/nginx/static/boot/";
             }
             location /dynamic/ {
                 resolver __DNS_RESOLVER__ valid=5s ipv6=off;


### PR DESCRIPTION
## Summary
- Reorganize `dataDir` subdirectory layout so each component has its own namespace
- Controller `--data-dir` now points to `dataDir/nginx/static`, so artifacts and boot configs land under `dataDir/nginx/static/artifacts/` and `dataDir/nginx/static/boot/`
- Nginx config alias updated to serve from `dataDir/nginx/static/boot/`
- dnsmasq init containers updated to read/write from the new paths
- Volume mounts stay at the top-level `dataDir` — only the subdirectory paths change

New layout under `dataDir`:
```
nginx/static/boot/       # boot.ipxe, kernel/initrd symlinks (served by nginx)
nginx/static/artifacts/  # downloaded artifacts (managed by controller)
dnsmasq/                 # reserved for dnsmasq (future use)
squid/cache/             # squid cache (added in #314)
squid/logs/              # squid logs (added in #314)
```

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [ ] `helm template` renders correct paths in all deployments
- [ ] Deploy and verify controller writes artifacts to `dataDir/nginx/static/artifacts/`
- [ ] Verify nginx serves boot files from `dataDir/nginx/static/boot/`
- [ ] Verify dnsmasq init generates `boot.ipxe` at new path
- [ ] Verify dnsmasq init finds iPXE tarball at new artifacts path
- [ ] PXE boot end-to-end still works with new directory layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)