### PR TITLE
Quote all interpolated Helm values

### DIFF
--- a/charts/isoboot/templates/deployment.yaml
+++ b/charts/isoboot/templates/deployment.yaml
@@ -4,8 +4,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "isoboot.fullname" . }}-controller-manager
-  namespace: {{ .Release.Namespace }}
+  name: "{{ include "isoboot.fullname" . }}-controller-manager"
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "isoboot.labels" . | nindent 4 }}
 spec:
@@ -22,7 +22,7 @@ spec:
         {{- include "isoboot.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: controller
     spec:
-      serviceAccountName: {{ include "isoboot.fullname" . }}-controller-manager
+      serviceAccountName: "{{ include "isoboot.fullname" . }}-controller-manager"
       terminationGracePeriodSeconds: 10
       affinity:
         nodeAffinity:

--- a/charts/isoboot/templates/metrics-service.yaml
+++ b/charts/isoboot/templates/metrics-service.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-metrics-service" (include "isoboot.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace }}
+  name: "{{ include "isoboot.fullname" . }}-metrics-service"
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "isoboot.labels" . | nindent 4 }}
 spec:

--- a/charts/isoboot/templates/rbac.yaml
+++ b/charts/isoboot/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "isoboot.fullname" . }}-manager-role
+  name: "{{ include "isoboot.fullname" . }}-manager-role"
   labels:
     {{- include "isoboot.labels" . | nindent 4 }}
 rules:
@@ -77,22 +77,22 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "isoboot.fullname" . }}-manager-rolebinding
+  name: "{{ include "isoboot.fullname" . }}-manager-rolebinding"
   labels:
     {{- include "isoboot.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "isoboot.fullname" . }}-manager-role
+  name: "{{ include "isoboot.fullname" . }}-manager-role"
 subjects:
 - kind: ServiceAccount
-  name: {{ include "isoboot.fullname" . }}-controller-manager
-  namespace: {{ .Release.Namespace }}
+  name: "{{ include "isoboot.fullname" . }}-controller-manager"
+  namespace: "{{ .Release.Namespace }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "isoboot.fullname" . }}-metrics-auth-role
+  name: "{{ include "isoboot.fullname" . }}-metrics-auth-role"
   labels:
     {{- include "isoboot.labels" . | nindent 4 }}
 rules:
@@ -112,17 +112,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "isoboot.fullname" . }}-metrics-auth-rolebinding
+  name: "{{ include "isoboot.fullname" . }}-metrics-auth-rolebinding"
   labels:
     {{- include "isoboot.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "isoboot.fullname" . }}-metrics-auth-role
+  name: "{{ include "isoboot.fullname" . }}-metrics-auth-role"
 subjects:
 - kind: ServiceAccount
-  name: {{ include "isoboot.fullname" . }}-controller-manager
-  namespace: {{ .Release.Namespace }}
+  name: "{{ include "isoboot.fullname" . }}-controller-manager"
+  namespace: "{{ .Release.Namespace }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -162,7 +162,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "isoboot.fullname" . }}-metrics-reader
+  name: "{{ include "isoboot.fullname" . }}-metrics-reader"
   labels:
     {{- include "isoboot.labels" . | nindent 4 }}
 rules:

--- a/charts/isoboot/templates/serviceaccount.yaml
+++ b/charts/isoboot/templates/serviceaccount.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "isoboot.fullname" . }}-controller-manager
-  namespace: {{ .Release.Namespace }}
+  name: "{{ include "isoboot.fullname" . }}-controller-manager"
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "isoboot.labels" . | nindent 4 }}
 ---


### PR DESCRIPTION
## Summary

Closes #317

- Quote all unquoted interpolated `name:` and `namespace:` fields in Helm templates to match the project convention from CLAUDE.md
- Simplify `metrics-service.yaml` name from unnecessary `printf` + `trunc 63` to the standard pattern used everywhere else

**Files fixed:** `deployment.yaml`, `rbac.yaml`, `serviceaccount.yaml`, `metrics-service.yaml`

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [ ] Verify rendered templates produce correct names

🤖 Generated with [Claude Code](https://claude.com/claude-code)