### PR TITLE
Fix E2E host paths for Helm deploy

### DIFF
--- a/.github/workflows/test-tag-helm-install.yaml
+++ b/.github/workflows/test-tag-helm-install.yaml
@@ -278,8 +278,8 @@ jobs:
 
     - name: Verify artifact SHA-256 on host disk
       run: |
-        echo "${{ env.VMLINUZ_SHA256 }}  /tmp/isoboot-data/artifacts/rocky-10.1-kernel/vmlinuz" | sha256sum -c
-        echo "${{ env.INITRD_SHA256 }}  /tmp/isoboot-data/artifacts/rocky-10.1-initrd/initrd.img" | sha256sum -c
+        echo "${{ env.VMLINUZ_SHA256 }}  /tmp/isoboot-data/nginx/static/artifacts/rocky-10.1-kernel/vmlinuz" | sha256sum -c
+        echo "${{ env.INITRD_SHA256 }}  /tmp/isoboot-data/nginx/static/artifacts/rocky-10.1-initrd/initrd.img" | sha256sum -c
 
     - name: Wait for BootConfig Ready
       run: ./test/e2e/wait-for-resource.sh -n isoboot-system bootconfig rocky-10.1
@@ -287,27 +287,27 @@ jobs:
     - name: Verify BootConfig symlinks on host disk
       run: |
         # Verify kernel symlink
-        target=$(readlink /tmp/isoboot-data/boot/rocky-10.1/kernel/vmlinuz)
+        target=$(readlink /tmp/isoboot-data/nginx/static/boot/rocky-10.1/kernel/vmlinuz)
         echo "kernel symlink target: $target"
         [ "$target" = "../../../artifacts/rocky-10.1-kernel/vmlinuz" ] || { echo "FAIL: wrong kernel target"; exit 1; }
 
         # Verify initrd symlink
-        target=$(readlink /tmp/isoboot-data/boot/rocky-10.1/initrd/initrd.img)
+        target=$(readlink /tmp/isoboot-data/nginx/static/boot/rocky-10.1/initrd/initrd.img)
         echo "initrd symlink target: $target"
         [ "$target" = "../../../artifacts/rocky-10.1-initrd/initrd.img" ] || { echo "FAIL: wrong initrd target"; exit 1; }
 
         # Verify symlinks resolve to actual files
-        test -f /tmp/isoboot-data/boot/rocky-10.1/kernel/vmlinuz || { echo "FAIL: kernel doesn't resolve"; exit 1; }
-        test -f /tmp/isoboot-data/boot/rocky-10.1/initrd/initrd.img || { echo "FAIL: initrd doesn't resolve"; exit 1; }
+        test -f /tmp/isoboot-data/nginx/static/boot/rocky-10.1/kernel/vmlinuz || { echo "FAIL: kernel doesn't resolve"; exit 1; }
+        test -f /tmp/isoboot-data/nginx/static/boot/rocky-10.1/initrd/initrd.img || { echo "FAIL: initrd doesn't resolve"; exit 1; }
 
     # ── Verify auto-generated boot script ─────────────────────────
     - name: Verify boot.ipxe auto-generated
       run: |
-        test -f /tmp/isoboot-data/boot/boot.ipxe || { echo "FAIL: boot.ipxe not found"; exit 1; }
-        grep 'chain' /tmp/isoboot-data/boot/boot.ipxe || { echo "FAIL: boot.ipxe missing chain directive"; exit 1; }
-        grep 'conditional-boot' /tmp/isoboot-data/boot/boot.ipxe || { echo "FAIL: boot.ipxe missing conditional-boot"; exit 1; }
+        test -f /tmp/isoboot-data/nginx/static/boot/boot.ipxe || { echo "FAIL: boot.ipxe not found"; exit 1; }
+        grep 'chain' /tmp/isoboot-data/nginx/static/boot/boot.ipxe || { echo "FAIL: boot.ipxe missing chain directive"; exit 1; }
+        grep 'conditional-boot' /tmp/isoboot-data/nginx/static/boot/boot.ipxe || { echo "FAIL: boot.ipxe missing conditional-boot"; exit 1; }
         echo "boot.ipxe auto-generated correctly:"
-        cat /tmp/isoboot-data/boot/boot.ipxe
+        cat /tmp/isoboot-data/nginx/static/boot/boot.ipxe
 
     # ── PXE download test: ns3 wget client ─────────────────────────
     - name: Start wget client container (ns3)


### PR DESCRIPTION
## Summary
- Fix host disk verification paths in `test-tag-helm-install.yaml` to include the `nginx/static` prefix
- The Helm chart passes `--data-dir={{ .Values.dataDir }}/nginx/static` to the controller, so artifacts and boot configs are written under `/tmp/isoboot-data/nginx/static/` on the host, not `/tmp/isoboot-data/` directly
- This was broken by #315 (Namespace dataDir by component) — the E2E paths were not updated to match

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [ ] Tag release workflow should pass with the corrected paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)