### PR TITLE
Add squid image push to tag workflow

### DIFF
--- a/.github/workflows/test-tag-helm-install.yaml
+++ b/.github/workflows/test-tag-helm-install.yaml
@@ -97,6 +97,19 @@ jobs:
         cache-from: type=gha,scope=httpd
         cache-to: type=gha,mode=max,scope=httpd
 
+    - name: Build and push squid image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile.squid
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          ${{ env.IMAGE }}-squid:${{ steps.version.outputs.version }}
+          ${{ !contains(steps.version.outputs.version, '-') && format('{0}-squid:latest', env.IMAGE) || '' }}
+        cache-from: type=gha,scope=squid
+        cache-to: type=gha,mode=max,scope=squid
+
     - uses: azure/setup-helm@v4
 
     - name: Package and push Helm chart


### PR DESCRIPTION
## Summary
- Add missing squid image build+push step to the tag release workflow
- Without this, `ghcr.io/isoboot/isoboot-squid` is never published, causing `ImagePullBackOff` on helm install

## Test plan
- [x] Trigger workflow via `workflow_dispatch` and verify squid image appears in GHCR — [passed](https://github.com/isoboot/isoboot/actions/runs/23111276579/job/67129043143)
- [x] Helm install and confirm squid pod starts without `ImagePullBackOff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)