### PR TITLE
Default Provision phase to Pending

### DIFF
--- a/api/v1alpha1/provision_types.go
+++ b/api/v1alpha1/provision_types.go
@@ -68,6 +68,7 @@ const (
 type ProvisionStatus struct {
 	// phase is the current phase of the provision.
 	// +optional
+	// +kubebuilder:default=Pending
 	Phase ProvisionPhase `json:"phase,omitempty"`
 
 	// message provides human-readable details about the current phase.

--- a/charts/isoboot/templates/crds.yaml
+++ b/charts/isoboot/templates/crds.yaml
@@ -410,6 +410,7 @@ spec:
                   phase.
                 type: string
               phase:
+                default: Pending
                 description: phase is the current phase of the provision.
                 enum:
                 - Pending

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -208,6 +208,13 @@ func main() {
 		setupLog.Error(err, "Failed to create controller", "controller", "BootConfig")
 		os.Exit(1)
 	}
+	if err := (&controller.ProvisionReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to create controller", "controller", "Provision")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/crd/bases/isoboot.github.io_provisions.yaml
+++ b/config/crd/bases/isoboot.github.io_provisions.yaml
@@ -103,6 +103,7 @@ spec:
                   phase.
                 type: string
               phase:
+                default: Pending
                 description: phase is the current phase of the provision.
                 enum:
                 - Pending

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,6 +41,7 @@ rules:
   resources:
   - bootartifacts/status
   - bootconfigs/status
+  - provisions/status
   verbs:
   - get
   - patch
@@ -56,9 +57,3 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - isoboot.github.io
-  resources:
-  - provisions/status
-  verbs:
-  - get

--- a/internal/controller/provision_controller.go
+++ b/internal/controller/provision_controller.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	isobootgithubiov1alpha1 "github.com/isoboot/isoboot/api/v1alpha1"
+)
+
+// ProvisionReconciler reconciles a Provision object
+type ProvisionReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=isoboot.github.io,resources=provisions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=isoboot.github.io,resources=provisions/status,verbs=get;update;patch
+
+func (r *ProvisionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	var prov isobootgithubiov1alpha1.Provision
+	if err := r.Get(ctx, req.NamespacedName, &prov); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if prov.Status.Phase == "" {
+		log.Info("Initializing Provision phase", "name", prov.Name)
+		prov.Status.Phase = isobootgithubiov1alpha1.ProvisionPhasePending
+		if err := r.Status().Update(ctx, &prov); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ProvisionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&isobootgithubiov1alpha1.Provision{}).
+		Named("provision").
+		Complete(r)
+}

--- a/internal/controller/provision_controller_test.go
+++ b/internal/controller/provision_controller_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	isobootgithubiov1alpha1 "github.com/isoboot/isoboot/api/v1alpha1"
+)
+
+var _ = Describe("Provision Controller", func() {
+	ctx := context.Background()
+
+	It("sets phase to Pending on a new Provision", func() {
+		prov := &isobootgithubiov1alpha1.Provision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-default-phase",
+				Namespace: "default",
+			},
+			Spec: isobootgithubiov1alpha1.ProvisionSpec{
+				MachineRef:             "some-machine",
+				BootConfigRef:          "some-bootconfig",
+				ProvisionAutomationRef: "some-automation",
+			},
+		}
+		Expect(k8sClient.Create(ctx, prov)).To(Succeed())
+		defer func() {
+			Expect(k8sClient.Delete(ctx, prov)).To(Succeed())
+		}()
+
+		reconciler := &ProvisionReconciler{
+			Client: k8sClient,
+			Scheme: scheme.Scheme,
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-default-phase",
+				Namespace: "default",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var fetched isobootgithubiov1alpha1.Provision
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      "test-default-phase",
+			Namespace: "default",
+		}, &fetched)).To(Succeed())
+		Expect(fetched.Status.Phase).To(Equal(
+			isobootgithubiov1alpha1.ProvisionPhasePending))
+	})
+
+	It("does not overwrite an existing phase", func() {
+		prov := &isobootgithubiov1alpha1.Provision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-existing-phase",
+				Namespace: "default",
+			},
+			Spec: isobootgithubiov1alpha1.ProvisionSpec{
+				MachineRef:             "some-machine",
+				BootConfigRef:          "some-bootconfig",
+				ProvisionAutomationRef: "some-automation",
+			},
+		}
+		Expect(k8sClient.Create(ctx, prov)).To(Succeed())
+		defer func() {
+			Expect(k8sClient.Delete(ctx, prov)).To(Succeed())
+		}()
+
+		// Set phase to Complete via status subresource.
+		prov.Status.Phase = isobootgithubiov1alpha1.ProvisionPhaseComplete
+		Expect(k8sClient.Status().Update(ctx, prov)).To(Succeed())
+
+		reconciler := &ProvisionReconciler{
+			Client: k8sClient,
+			Scheme: scheme.Scheme,
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-existing-phase",
+				Namespace: "default",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var fetched isobootgithubiov1alpha1.Provision
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      "test-existing-phase",
+			Namespace: "default",
+		}, &fetched)).To(Succeed())
+		Expect(fetched.Status.Phase).To(Equal(
+			isobootgithubiov1alpha1.ProvisionPhaseComplete))
+	})
+})


### PR DESCRIPTION
## Summary
- Add `+kubebuilder:default=Pending` to the Provision CRD's `status.phase` field
- Add a `ProvisionReconciler` that sets `status.phase` to `Pending` when a new Provision is created with no phase (the status subresource strips status on create, so the schema default alone isn't sufficient)
- Regenerated CRD base manifest and updated the Helm chart CRD template to match

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [x] Unit test: new Provision gets phase set to `Pending` by reconciler
- [x] Unit test: reconciler does not overwrite an existing phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)