### PR TITLE
Add rc8 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.1-rc8
+
+- Default new Provision phase to Pending via reconciler
+
 ## v0.0.1-rc7
 
 - Run squid as non-root (UID 31) with drop ALL capabilities


### PR DESCRIPTION
## Summary
- Add v0.0.1-rc8 changelog entry for Provision default phase feature

## Test plan
- [ ] Changelog format matches prior entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)