### PR TITLE
Add kernel args template rendering

### DIFF
--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -158,6 +158,23 @@ func conditionalBootHandler(getDirective bootDirectiveFunc) http.HandlerFunc {
 
 		slog.Info("conditional-boot request", "mac", mac)
 
+		if directive.KernelArgs != "" {
+			baseURL := fmt.Sprintf("http://%s/dynamic/automation/%s",
+				r.Host, directive.ProvisionName)
+			rendered, err := httpd.RenderKernelArgs(
+				directive.KernelArgs, httpd.KernelArgsData{
+					ProvisionAutomationBaseURL: baseURL,
+				})
+			if err != nil {
+				slog.Error("kernel args template failed",
+					"mac", mac, "error", err)
+				http.Error(w, "internal error",
+					http.StatusInternalServerError)
+				return
+			}
+			directive.KernelArgs = rendered
+		}
+
 		kernelLine := fmt.Sprintf("kernel /static/%s", directive.KernelPath)
 		if directive.KernelArgs != "" {
 			kernelLine += " " + directive.KernelArgs

--- a/cmd/httpd/main_test.go
+++ b/cmd/httpd/main_test.go
@@ -16,9 +16,10 @@ import (
 func fixedDirective() bootDirectiveFunc {
 	return func(_ context.Context, _ string) (*httpd.BootDirective, error) {
 		return &httpd.BootDirective{
-			KernelPath: "test-config/kernel/vmlinuz",
-			KernelArgs: "console=ttyS0",
-			InitrdPath: "test-config/initrd/initrd.img",
+			KernelPath:    "test-config/kernel/vmlinuz",
+			KernelArgs:    "console=ttyS0",
+			InitrdPath:    "test-config/initrd/initrd.img",
+			ProvisionName: "test-provision",
 		}, nil
 	}
 }
@@ -122,6 +123,50 @@ func TestConditionalBoot_NoKernelArgs(t *testing.T) {
 	expected := "#!ipxe\nkernel /static/config/kernel/vmlinuz\ninitrd /static/config/initrd/initrd.img\nboot\n"
 	if string(body) != expected {
 		t.Errorf("expected:\n%s\ngot:\n%s", expected, string(body))
+	}
+}
+
+func TestConditionalBoot_TemplateRendering(t *testing.T) {
+	handler := conditionalBootHandler(func(_ context.Context, _ string) (*httpd.BootDirective, error) {
+		return &httpd.BootDirective{
+			KernelPath:    "config/kernel/vmlinuz",
+			KernelArgs:    "ip=dhcp inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg",
+			InitrdPath:    "config/initrd/initrd.img",
+			ProvisionName: "my-provision",
+		}, nil
+	})
+	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got: %d", w.Result().StatusCode)
+	}
+	body, _ := io.ReadAll(w.Result().Body)
+	expected := "ip=dhcp inst.ks=http://" + req.Host +
+		"/dynamic/automation/my-provision/ks.cfg"
+	if !strings.Contains(string(body), expected) {
+		t.Errorf("expected body to contain:\n%s\ngot:\n%s", expected, body)
+	}
+}
+
+func TestConditionalBoot_TemplateError(t *testing.T) {
+	handler := conditionalBootHandler(func(_ context.Context, _ string) (*httpd.BootDirective, error) {
+		return &httpd.BootDirective{
+			KernelPath:    "config/kernel/vmlinuz",
+			KernelArgs:    "{{.UnknownVar}}",
+			InitrdPath:    "config/initrd/initrd.img",
+			ProvisionName: "my-provision",
+		}, nil
+	})
+	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got: %d", w.Result().StatusCode)
 	}
 }
 

--- a/cmd/httpd/main_test.go
+++ b/cmd/httpd/main_test.go
@@ -136,6 +136,7 @@ func TestConditionalBoot_TemplateRendering(t *testing.T) {
 		}, nil
 	})
 	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
+	req.Host = "10.0.0.1:8080"
 	w := httptest.NewRecorder()
 
 	handler(w, req)
@@ -144,8 +145,7 @@ func TestConditionalBoot_TemplateRendering(t *testing.T) {
 		t.Fatalf("expected 200, got: %d", w.Result().StatusCode)
 	}
 	body, _ := io.ReadAll(w.Result().Body)
-	expected := "ip=dhcp inst.ks=http://" + req.Host +
-		"/dynamic/automation/my-provision/ks.cfg"
+	expected := "ip=dhcp inst.ks=http://10.0.0.1:8080/dynamic/automation/my-provision/ks.cfg"
 	if !strings.Contains(string(body), expected) {
 		t.Errorf("expected body to contain:\n%s\ngot:\n%s", expected, body)
 	}

--- a/internal/httpd/boot.go
+++ b/internal/httpd/boot.go
@@ -17,10 +17,12 @@ limitations under the License.
 package httpd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"path"
+	"text/template"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -30,9 +32,31 @@ import (
 
 // BootDirective holds the data needed to construct an iPXE boot script.
 type BootDirective struct {
-	KernelPath string
-	KernelArgs string
-	InitrdPath string
+	KernelPath    string
+	KernelArgs    string
+	InitrdPath    string
+	ProvisionName string
+}
+
+// KernelArgsData holds the template data for kernel args rendering.
+type KernelArgsData struct {
+	ProvisionAutomationBaseURL string
+}
+
+// RenderKernelArgs renders kernel args as a Go template with the given data.
+func RenderKernelArgs(args string, data KernelArgsData) (string, error) {
+	tmpl, err := template.New("kernelArgs").
+		Option("missingkey=error").Parse(args)
+	if err != nil {
+		return "", fmt.Errorf("parsing kernel args template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("executing kernel args template: %w", err)
+	}
+
+	return buf.String(), nil
 }
 
 // IsDuplicateError reports whether err indicates a duplicate machine or provision.
@@ -90,8 +114,9 @@ func BootDirectiveForMAC(
 	initrdFile := urlutil.FilenameFromURL(initrdArtifact.Spec.URL)
 
 	return &BootDirective{
-		KernelPath: path.Join(bc.Name, "kernel", kernelFile),
-		KernelArgs: bc.Spec.Kernel.Args,
-		InitrdPath: path.Join(bc.Name, "initrd", initrdFile),
+		KernelPath:    path.Join(bc.Name, "kernel", kernelFile),
+		KernelArgs:    bc.Spec.Kernel.Args,
+		InitrdPath:    path.Join(bc.Name, "initrd", initrdFile),
+		ProvisionName: provision.Name,
 	}, nil
 }

--- a/internal/httpd/boot_test.go
+++ b/internal/httpd/boot_test.go
@@ -99,6 +99,7 @@ var _ = Describe("BootDirectiveForMAC", func() {
 		Expect(result.KernelPath).To(Equal("bd-bc1/kernel/vmlinuz"))
 		Expect(result.KernelArgs).To(Equal("console=ttyS0"))
 		Expect(result.InitrdPath).To(Equal("bd-bc1/initrd/initrd.img"))
+		Expect(result.ProvisionName).To(Equal("bd-p1"))
 	})
 
 	It("returns directive with empty kernel args", func() {
@@ -143,6 +144,44 @@ var _ = Describe("BootDirectiveForMAC", func() {
 				ctx, indexedClient, ns, "bb-00-00-00-00-03")
 			return err
 		}).Should(MatchError(ContainSubstring("getting boot config")))
+	})
+})
+
+var _ = Describe("RenderKernelArgs", func() {
+	data := KernelArgsData{
+		ProvisionAutomationBaseURL: "http://10.0.0.1:8080/dynamic/automation/my-provision",
+	}
+
+	It("passes through plain string unchanged", func() {
+		result, err := RenderKernelArgs("console=ttyS0 ip=dhcp", data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("console=ttyS0 ip=dhcp"))
+	})
+
+	It("renders ProvisionAutomationBaseURL", func() {
+		result, err := RenderKernelArgs(
+			"ip=dhcp inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg", data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(
+			"ip=dhcp inst.ks=http://10.0.0.1:8080/dynamic/automation/my-provision/ks.cfg"))
+	})
+
+	It("returns empty string for empty input", func() {
+		result, err := RenderKernelArgs("", data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeEmpty())
+	})
+
+	It("returns error for invalid template syntax", func() {
+		_, err := RenderKernelArgs("{{.Foo", data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("parsing kernel args template"))
+	})
+
+	It("returns error for unknown variable", func() {
+		_, err := RenderKernelArgs("{{.UnknownVar}}", data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("executing kernel args template"))
 	})
 })
 


### PR DESCRIPTION
## Summary
- Add `{{.ProvisionAutomationBaseURL}}` Go template variable to `BootConfig.Spec.Kernel.Args`
- At iPXE boot time, resolves to `http://<server>/dynamic/automation/<provision-name>` so users can append filenames like `/ks.cfg`
- Uses `text/template` with `missingkey=error`, matching the existing ProvisionAutomation rendering pattern

## Test plan
- [x] `RenderKernelArgs` unit tests: plain passthrough, template substitution, empty input, invalid syntax, unknown variable
- [x] `BootDirectiveForMAC` returns `ProvisionName`
- [x] Handler renders template in iPXE output with correct URL
- [x] Handler returns 500 on template error
- [x] `make lint` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)