### PR TITLE
Add kernel args to rocky example

### DIFF
--- a/examples/rocky-10.1.yaml
+++ b/examples/rocky-10.1.yaml
@@ -27,6 +27,6 @@ metadata:
 spec:
   kernel:
     ref: rocky-10.1-kernel
-    args: "ip=dhcp inst.repo=http://repo.almalinux.org/almalinux/10.1/BaseOS/x86_64/os inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg"
+    args: "ip=dhcp inst.repo=https://download.rockylinux.org/pub/rocky/10.1/BaseOS/x86_64/os inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg"
   initrd:
     ref: rocky-10.1-initrd

--- a/examples/rocky-10.1.yaml
+++ b/examples/rocky-10.1.yaml
@@ -27,5 +27,6 @@ metadata:
 spec:
   kernel:
     ref: rocky-10.1-kernel
+    args: "ip=dhcp inst.repo=http://repo.almalinux.org/almalinux/10.1/BaseOS/x86_64/os inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg"
   initrd:
     ref: rocky-10.1-initrd


### PR DESCRIPTION
## Summary
- Add `args` with `inst.repo` and `inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg` to the rocky-10.1 BootConfig example

## Test plan
- [ ] Verify example applies cleanly with `kubectl apply -f examples/rocky-10.1.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)