### PR TITLE
Use X-Forwarded-Host for base URL

### DIFF
--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -164,7 +165,11 @@ func conditionalBootHandler(getDirective bootDirectiveFunc) http.HandlerFunc {
 				host = r.Host
 			}
 			if port := r.Header.Get("X-Forwarded-Port"); port != "" {
-				host = host + ":" + port
+				h, _, _ := net.SplitHostPort(host)
+				if h != "" {
+					host = h
+				}
+				host = net.JoinHostPort(host, port)
 			}
 			baseURL := fmt.Sprintf("http://%s/dynamic/automation/%s",
 				host, directive.ProvisionName)

--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -159,8 +159,15 @@ func conditionalBootHandler(getDirective bootDirectiveFunc) http.HandlerFunc {
 		slog.Info("conditional-boot request", "mac", mac)
 
 		if directive.KernelArgs != "" {
+			host := r.Header.Get("X-Forwarded-Host")
+			if host == "" {
+				host = r.Host
+			}
+			if port := r.Header.Get("X-Forwarded-Port"); port != "" {
+				host = host + ":" + port
+			}
 			baseURL := fmt.Sprintf("http://%s/dynamic/automation/%s",
-				r.Host, directive.ProvisionName)
+				host, directive.ProvisionName)
 			rendered, err := httpd.RenderKernelArgs(
 				directive.KernelArgs, httpd.KernelArgsData{
 					ProvisionAutomationBaseURL: baseURL,

--- a/cmd/httpd/main_test.go
+++ b/cmd/httpd/main_test.go
@@ -136,7 +136,8 @@ func TestConditionalBoot_TemplateRendering(t *testing.T) {
 		}, nil
 	})
 	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
-	req.Host = "10.0.0.1:8080"
+	req.Header.Set("X-Forwarded-Host", "10.0.0.1")
+	req.Header.Set("X-Forwarded-Port", "8080")
 	w := httptest.NewRecorder()
 
 	handler(w, req)

--- a/cmd/httpd/main_test.go
+++ b/cmd/httpd/main_test.go
@@ -152,6 +152,31 @@ func TestConditionalBoot_TemplateRendering(t *testing.T) {
 	}
 }
 
+func TestConditionalBoot_TemplateRenderingFallback(t *testing.T) {
+	handler := conditionalBootHandler(func(_ context.Context, _ string) (*httpd.BootDirective, error) {
+		return &httpd.BootDirective{
+			KernelPath:    "config/kernel/vmlinuz",
+			KernelArgs:    "ip=dhcp inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg",
+			InitrdPath:    "config/initrd/initrd.img",
+			ProvisionName: "my-provision",
+		}, nil
+	})
+	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
+	req.Host = "10.0.0.1:8080"
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got: %d", w.Result().StatusCode)
+	}
+	body, _ := io.ReadAll(w.Result().Body)
+	expected := "ip=dhcp inst.ks=http://10.0.0.1:8080/dynamic/automation/my-provision/ks.cfg"
+	if !strings.Contains(string(body), expected) {
+		t.Errorf("expected body to contain:\n%s\ngot:\n%s", expected, body)
+	}
+}
+
 func TestConditionalBoot_TemplateError(t *testing.T) {
 	handler := conditionalBootHandler(func(_ context.Context, _ string) (*httpd.BootDirective, error) {
 		return &httpd.BootDirective{


### PR DESCRIPTION
## Summary
- Use `X-Forwarded-Host` and `X-Forwarded-Port` headers from nginx to construct `ProvisionAutomationBaseURL` instead of `r.Host`
- Fixes the rendered URL resolving to the cluster-internal service address instead of the external IP

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [x] Template rendering test uses forwarded headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)