### PR TITLE
Drop /dynamic prefix from Go route

### DIFF
--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -88,7 +88,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /conditional-boot", handler)
-	mux.HandleFunc("GET /dynamic/automation/{provisionName}/{fileName}", automationHandler)
+	mux.HandleFunc("GET /automation/{provisionName}/{fileName}", automationHandler)
 	mux.HandleFunc("GET /healthz", healthzHandler)
 
 	srv := &http.Server{


### PR DESCRIPTION
## Summary
- Remove `/dynamic` prefix from the Go httpd automation route since nginx already strips it via rewrite
- Fixes 404 when accessing automation files through nginx

## Test plan
- [x] `make test` passes
- [x] `curl http://192.168.4.239:8080/dynamic/automation/qemu-vm1-rocky-10-1/ks.cfg` should now work through nginx

🤖 Generated with [Claude Code](https://claude.com/claude-code)