### PR TITLE
Add httpd RBAC for automation endpoint

### DIFF
--- a/charts/isoboot/templates/rbac.yaml
+++ b/charts/isoboot/templates/rbac.yaml
@@ -9,6 +9,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -45,14 +52,8 @@ rules:
   - isoboot.github.io
   resources:
   - bootconfigs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - isoboot.github.io
-  resources:
   - machines
+  - provisions
   verbs:
   - get
   - list
@@ -63,16 +64,6 @@ rules:
   - provisionautomations
   verbs:
   - get
-  - list
-  - watch
-- apiGroups:
-  - isoboot.github.io
-  resources:
-  - provisions
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/isoboot/templates/rbac.yaml
+++ b/charts/isoboot/templates/rbac.yaml
@@ -132,10 +132,23 @@ metadata:
     {{- include "isoboot.labels" . | nindent 4 }}
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+- apiGroups:
   - isoboot.github.io
   resources:
   - bootartifacts
   - bootconfigs
+  - provisionautomations
+  verbs:
+  - get
+- apiGroups:
+  - isoboot.github.io
+  resources:
   - machines
   - provisions
   verbs:

--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -15,10 +15,12 @@ import (
 	"syscall"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -46,6 +48,17 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&isobootgithubiov1alpha1.BootArtifact{},
+					&isobootgithubiov1alpha1.BootConfig{},
+					&isobootgithubiov1alpha1.ProvisionAutomation{},
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
+				},
+			},
+		},
 	})
 	if err != nil {
 		slog.Error("failed to create manager", "error", err)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -51,9 +51,14 @@ rules:
   resources:
   - bootconfigs
   - machines
-  - provisionautomations
   - provisions
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - isoboot.github.io
+  resources:
+  - provisionautomations
+  verbs:
+  - get

--- a/internal/controller/indexers.go
+++ b/internal/controller/indexers.go
@@ -40,9 +40,8 @@ const MachineSpecMACField = "spec.mac"
 // +kubebuilder:rbac:groups=isoboot.github.io,resources=provisions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=isoboot.github.io,resources=provisions/status,verbs=get
 // +kubebuilder:rbac:groups=isoboot.github.io,resources=machines,verbs=get;list;watch
-// +kubebuilder:rbac:groups=isoboot.github.io,resources=provisionautomations,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get
+// +kubebuilder:rbac:groups=isoboot.github.io,resources=bootartifacts;bootconfigs;provisionautomations,verbs=get
+// +kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=get
 
 // SetupIndexers registers field indexes on the manager's cache.
 func SetupIndexers(ctx context.Context, mgr manager.Manager) error {


### PR DESCRIPTION
## Summary
- Add missing RBAC permissions for httpd service account to access `provisionautomations`, `configmaps`, and `secrets`
- Bypass cache (`DisableFor`) for types without indexers: `BootArtifact`, `BootConfig`, `ProvisionAutomation`, `ConfigMap`, `Secret`
- Only `machines` and `provisions` (which have field indexers) use the cache with `get`/`list`/`watch`
- All other types use direct API calls with `get` only — least privilege

## Test plan
- [x] `make lint` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)