### PR TITLE
Add v0.0.1 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Rocky Linux 10.1 fully automated installation tested with a 7-line
   kickstart file (lang, keyboard, timezone, autopart, clearpart, zerombr, user)
+- Known limitations: no squid cache (#349), SSH host keys not tested (#350),
+  hostname not tested (#351), SSH public key not tested (#352),
+  call home provision phase update not implemented (#353)
 
 ## v0.0.1-rc12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.0.1
+
+- Rocky Linux 10.1 fully automated installation tested with a 7-line
+  kickstart file (lang, keyboard, timezone, autopart, clearpart, zerombr, user)
+
 ## v0.0.1-rc12
 
 - Add httpd RBAC for automation endpoint


### PR DESCRIPTION
## Summary
- Add v0.0.1 release entry to CHANGELOG noting Rocky Linux 10.1 fully automated installation with a 7-line kickstart file
- Known limitations tracked in #349, #350, #351, #352, #353

## Test plan
- [x] `make lint` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)