### PR TITLE
Add proxy URL to kernel args template

### DIFF
--- a/charts/isoboot/templates/httpd-deployment.yaml
+++ b/charts/isoboot/templates/httpd-deployment.yaml
@@ -31,6 +31,9 @@ spec:
         args:
         - "--listen-addr=:{{ .Values.httpd.port }}"
         - "--namespace={{ .Release.Namespace }}"
+        env:
+        - name: PROXY_PORT
+          value: "{{ .Values.squid.port }}"
         ports:
         - containerPort: {{ .Values.httpd.port }}
           protocol: TCP

--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -87,10 +87,11 @@ func main() {
 
 	c := mgr.GetClient()
 	ns := *namespace
+	proxyPort := os.Getenv("PROXY_PORT")
 
 	handler := conditionalBootHandler(func(reqCtx context.Context, mac string) (*httpd.BootDirective, error) {
 		return httpd.BootDirectiveForMAC(reqCtx, c, ns, mac)
-	})
+	}, proxyPort)
 
 	renderFile := func(
 		reqCtx context.Context, provisionName, fileName string,
@@ -141,7 +142,7 @@ func main() {
 	}
 }
 
-func conditionalBootHandler(getDirective bootDirectiveFunc) http.HandlerFunc {
+func conditionalBootHandler(getDirective bootDirectiveFunc, proxyPort string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		mac := r.URL.Query().Get("mac")
 		if mac == "" {
@@ -177,6 +178,10 @@ func conditionalBootHandler(getDirective bootDirectiveFunc) http.HandlerFunc {
 			if host == "" {
 				host = r.Host
 			}
+			nodeIP := host
+			if h, _, err := net.SplitHostPort(nodeIP); err == nil {
+				nodeIP = h
+			}
 			if port := r.Header.Get("X-Forwarded-Port"); port != "" {
 				h, _, _ := net.SplitHostPort(host)
 				if h != "" {
@@ -186,9 +191,14 @@ func conditionalBootHandler(getDirective bootDirectiveFunc) http.HandlerFunc {
 			}
 			baseURL := fmt.Sprintf("http://%s/dynamic/automation/%s",
 				host, directive.ProvisionName)
+			proxyURL := ""
+			if proxyPort != "" {
+				proxyURL = fmt.Sprintf("http://%s:%s", nodeIP, proxyPort)
+			}
 			rendered, err := httpd.RenderKernelArgs(
 				directive.KernelArgs, httpd.KernelArgsData{
 					ProvisionAutomationBaseURL: baseURL,
+					ProxyURL:                   proxyURL,
 				})
 			if err != nil {
 				slog.Error("kernel args template failed",

--- a/cmd/httpd/main_test.go
+++ b/cmd/httpd/main_test.go
@@ -62,7 +62,7 @@ func TestConditionalBoot_StatusCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := conditionalBootHandler(tt.directive)
+			handler := conditionalBootHandler(tt.directive, "")
 			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
 			w := httptest.NewRecorder()
 
@@ -76,7 +76,7 @@ func TestConditionalBoot_StatusCodes(t *testing.T) {
 }
 
 func TestConditionalBoot_ContentType(t *testing.T) {
-	handler := conditionalBootHandler(fixedDirective())
+	handler := conditionalBootHandler(fixedDirective(), "")
 	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 
@@ -89,7 +89,7 @@ func TestConditionalBoot_ContentType(t *testing.T) {
 }
 
 func TestConditionalBoot_BootDirective(t *testing.T) {
-	handler := conditionalBootHandler(fixedDirective())
+	handler := conditionalBootHandler(fixedDirective(), "")
 	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 
@@ -110,7 +110,7 @@ func TestConditionalBoot_NoKernelArgs(t *testing.T) {
 			KernelPath: "config/kernel/vmlinuz",
 			InitrdPath: "config/initrd/initrd.img",
 		}, nil
-	})
+	}, "")
 	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 
@@ -134,7 +134,7 @@ func TestConditionalBoot_TemplateRendering(t *testing.T) {
 			InitrdPath:    "config/initrd/initrd.img",
 			ProvisionName: "my-provision",
 		}, nil
-	})
+	}, "")
 	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	req.Header.Set("X-Forwarded-Host", "10.0.0.1")
 	req.Header.Set("X-Forwarded-Port", "8080")
@@ -160,7 +160,7 @@ func TestConditionalBoot_TemplateRenderingFallback(t *testing.T) {
 			InitrdPath:    "config/initrd/initrd.img",
 			ProvisionName: "my-provision",
 		}, nil
-	})
+	}, "")
 	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	req.Host = "10.0.0.1:8080"
 	w := httptest.NewRecorder()
@@ -177,6 +177,34 @@ func TestConditionalBoot_TemplateRenderingFallback(t *testing.T) {
 	}
 }
 
+func TestConditionalBoot_ProxyURL(t *testing.T) {
+	handler := conditionalBootHandler(func(_ context.Context, _ string) (*httpd.BootDirective, error) {
+		return &httpd.BootDirective{
+			KernelPath:    "config/kernel/vmlinuz",
+			KernelArgs:    "ip=dhcp inst.proxy={{.ProxyURL}} inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg",
+			InitrdPath:    "config/initrd/initrd.img",
+			ProvisionName: "my-provision",
+		}, nil
+	}, "3128")
+	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
+	req.Header.Set("X-Forwarded-Host", "10.0.0.1")
+	req.Header.Set("X-Forwarded-Port", "8080")
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got: %d", w.Result().StatusCode)
+	}
+	body, _ := io.ReadAll(w.Result().Body)
+	if !strings.Contains(string(body), "inst.proxy=http://10.0.0.1:3128") {
+		t.Errorf("expected body to contain inst.proxy=http://10.0.0.1:3128, got:\n%s", body)
+	}
+	if !strings.Contains(string(body), "inst.ks=http://10.0.0.1:8080/dynamic/automation/my-provision/ks.cfg") {
+		t.Errorf("expected body to contain inst.ks URL, got:\n%s", body)
+	}
+}
+
 func TestConditionalBoot_TemplateError(t *testing.T) {
 	handler := conditionalBootHandler(func(_ context.Context, _ string) (*httpd.BootDirective, error) {
 		return &httpd.BootDirective{
@@ -185,7 +213,7 @@ func TestConditionalBoot_TemplateError(t *testing.T) {
 			InitrdPath:    "config/initrd/initrd.img",
 			ProvisionName: "my-provision",
 		}, nil
-	})
+	}, "")
 	req := httptest.NewRequest(http.MethodGet, "/conditional-boot?mac=aa-bb-cc-dd-ee-ff", nil)
 	w := httptest.NewRecorder()
 

--- a/examples/rocky-10.1.yaml
+++ b/examples/rocky-10.1.yaml
@@ -27,6 +27,6 @@ metadata:
 spec:
   kernel:
     ref: rocky-10.1-kernel
-    args: "ip=dhcp inst.proxy={{.ProxyURL}} inst.repo=https://download.rockylinux.org/pub/rocky/10.1/BaseOS/x86_64/os inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg"
+    args: "ip=dhcp {{if .ProxyURL}}inst.proxy={{.ProxyURL}} {{end}}inst.repo=https://download.rockylinux.org/pub/rocky/10.1/BaseOS/x86_64/os inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg"
   initrd:
     ref: rocky-10.1-initrd

--- a/examples/rocky-10.1.yaml
+++ b/examples/rocky-10.1.yaml
@@ -27,6 +27,6 @@ metadata:
 spec:
   kernel:
     ref: rocky-10.1-kernel
-    args: "ip=dhcp inst.repo=https://download.rockylinux.org/pub/rocky/10.1/BaseOS/x86_64/os inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg"
+    args: "ip=dhcp inst.proxy={{.ProxyURL}} inst.repo=https://download.rockylinux.org/pub/rocky/10.1/BaseOS/x86_64/os inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg"
   initrd:
     ref: rocky-10.1-initrd

--- a/internal/httpd/boot.go
+++ b/internal/httpd/boot.go
@@ -41,6 +41,7 @@ type BootDirective struct {
 // KernelArgsData holds the template data for kernel args rendering.
 type KernelArgsData struct {
 	ProvisionAutomationBaseURL string
+	ProxyURL                   string
 }
 
 // RenderKernelArgs renders kernel args as a Go template with the given data.

--- a/internal/httpd/boot_test.go
+++ b/internal/httpd/boot_test.go
@@ -166,6 +166,18 @@ var _ = Describe("RenderKernelArgs", func() {
 			"ip=dhcp inst.ks=http://10.0.0.1:8080/dynamic/automation/my-provision/ks.cfg"))
 	})
 
+	It("renders ProxyURL", func() {
+		result, err := RenderKernelArgs(
+			"ip=dhcp inst.proxy={{.ProxyURL}} inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg",
+			KernelArgsData{
+				ProvisionAutomationBaseURL: "http://10.0.0.1:8080/dynamic/automation/my-provision",
+				ProxyURL:                   "http://10.0.0.1:3128",
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(
+			"ip=dhcp inst.proxy=http://10.0.0.1:3128 inst.ks=http://10.0.0.1:8080/dynamic/automation/my-provision/ks.cfg"))
+	})
+
 	It("returns empty string for empty input", func() {
 		result, err := RenderKernelArgs("", data)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/httpd/boot_test.go
+++ b/internal/httpd/boot_test.go
@@ -178,6 +178,16 @@ var _ = Describe("RenderKernelArgs", func() {
 			"ip=dhcp inst.proxy=http://10.0.0.1:3128 inst.ks=http://10.0.0.1:8080/dynamic/automation/my-provision/ks.cfg"))
 	})
 
+	It("omits ProxyURL block when empty", func() {
+		result, err := RenderKernelArgs(
+			"ip=dhcp {{if .ProxyURL}}inst.proxy={{.ProxyURL}} {{end}}inst.repo=https://example.com",
+			KernelArgsData{
+				ProvisionAutomationBaseURL: "http://10.0.0.1:8080/dynamic/automation/my-provision",
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("ip=dhcp inst.repo=https://example.com"))
+	})
+
 	It("returns empty string for empty input", func() {
 		result, err := RenderKernelArgs("", data)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
- Add `ProxyURL` template variable to `KernelArgsData`, constructed from node IP + `PROXY_PORT` env var at request time
- Set `PROXY_PORT` env var in httpd Helm deployment from `.Values.squid.port`
- Update Rocky example to include `inst.proxy={{.ProxyURL}}` so Anaconda routes downloads through squid

Closes #349

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [x] New Ginkgo test verifies `{{.ProxyURL}}` template rendering
- [x] New handler test verifies `inst.proxy=http://10.0.0.1:3128` in iPXE output

🤖 Generated with [Claude Code](https://claude.com/claude-code)