### PR TITLE
Use HTTP repo URL for Squid caching

### DIFF
--- a/examples/rocky-10.1.yaml
+++ b/examples/rocky-10.1.yaml
@@ -27,6 +27,6 @@ metadata:
 spec:
   kernel:
     ref: rocky-10.1-kernel
-    args: "ip=dhcp {{if .ProxyURL}}inst.proxy={{.ProxyURL}} {{end}}inst.repo=https://download.rockylinux.org/pub/rocky/10.1/BaseOS/x86_64/os inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg"
+    args: "ip=dhcp {{if .ProxyURL}}inst.proxy={{.ProxyURL}} {{end}}inst.repo=http://download.rockylinux.org/pub/rocky/10.1/BaseOS/x86_64/os inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg"
   initrd:
     ref: rocky-10.1-initrd


### PR DESCRIPTION
## Summary
- Change `inst.repo` URL from `https://` to `http://` in the Rocky 10.1 example
- Squid cannot cache HTTPS traffic (CONNECT tunnel is opaque), so all installer package downloads were bypassing the cache
- RPM package integrity is still verified via GPG signatures regardless of transport

## Test plan
- [x] Verified HTTP URL returns 200 through Squid proxy
- [x] Verified Squid caches HTTP downloads (cache grew from 17M to 81M, second request served in 0.1s vs 1.5s)
- [x] `make lint` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)