### PR TITLE
Log Squid access and cache to files

### DIFF
--- a/charts/isoboot/templates/squid-configmap.yaml
+++ b/charts/isoboot/templates/squid-configmap.yaml
@@ -15,6 +15,6 @@ data:
     maximum_object_size {{ .Values.squid.maxObjectSize }}
     cache_mem {{ .Values.squid.cacheMemMB }} MB
     cache_dir ufs /var/cache/squid {{ .Values.squid.cacheSizeMB }} 16 256
-    access_log stdio:/dev/stdout
-    cache_log stdio:/dev/stderr
+    access_log stdio:/var/log/squid/access.log
+    cache_log stdio:/var/log/squid/cache.log
     pid_filename /run/squid/squid.pid


### PR DESCRIPTION
## Summary
- Write Squid access and cache logs to `/var/log/squid/` files instead of `/dev/stdout` and `/dev/stderr`
- Squid's PID 1 redirects stdout to `/dev/null` even with `--foreground`, so `access_log stdio:/dev/stdout` silently drops all log output
- The `/var/log/squid` volume is already mounted as a hostPath, so logs persist and are readable via `kubectl exec`

## Test plan
- [ ] Deploy updated chart and verify `access.log` and `cache.log` are written to `/var/log/squid/`
- [ ] Verify logs appear after making requests through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)