### PR TITLE
Add Squid log toggle settings

### DIFF
--- a/charts/isoboot/templates/squid-configmap.yaml
+++ b/charts/isoboot/templates/squid-configmap.yaml
@@ -16,5 +16,5 @@ data:
     cache_mem {{ .Values.squid.cacheMemMB }} MB
     cache_dir ufs /var/cache/squid {{ .Values.squid.cacheSizeMB }} 16 256
     access_log {{ if .Values.squid.log.access }}stdio:/var/log/squid/access.log{{ else }}none{{ end }}
-    cache_log {{ if .Values.squid.log.cache }}/var/log/squid/cache.log{{ else }}/dev/null{{ end }}
+    cache_log /var/log/squid/cache.log
     pid_filename /run/squid/squid.pid

--- a/charts/isoboot/templates/squid-configmap.yaml
+++ b/charts/isoboot/templates/squid-configmap.yaml
@@ -15,6 +15,6 @@ data:
     maximum_object_size {{ .Values.squid.maxObjectSize }}
     cache_mem {{ .Values.squid.cacheMemMB }} MB
     cache_dir ufs /var/cache/squid {{ .Values.squid.cacheSizeMB }} 16 256
-    access_log stdio:/var/log/squid/access.log
-    cache_log stdio:/var/log/squid/cache.log
+    access_log {{ if .Values.squid.log.access }}stdio:/var/log/squid/access.log{{ else }}none{{ end }}
+    cache_log {{ if .Values.squid.log.cache }}/var/log/squid/cache.log{{ else }}/dev/null{{ end }}
     pid_filename /run/squid/squid.pid

--- a/charts/isoboot/templates/squid-configmap.yaml
+++ b/charts/isoboot/templates/squid-configmap.yaml
@@ -15,6 +15,10 @@ data:
     maximum_object_size {{ .Values.squid.maxObjectSize }}
     cache_mem {{ .Values.squid.cacheMemMB }} MB
     cache_dir ufs /var/cache/squid {{ .Values.squid.cacheSizeMB }} 16 256
-    access_log {{ if .Values.squid.log.access }}stdio:/var/log/squid/access.log{{ else }}none{{ end }}
+    {{- if .Values.squid.log.access }}
+    access_log stdio:/var/log/squid/access.log
+    {{- else }}
+    access_log none
+    {{- end }}
     cache_log /var/log/squid/cache.log
     pid_filename /run/squid/squid.pid

--- a/charts/isoboot/values.yaml
+++ b/charts/isoboot/values.yaml
@@ -70,7 +70,6 @@ squid:
   cacheSizeMB: 8000
   log:
     access: false
-    cache: true
   resources:
     limits:
       cpu: 500m

--- a/charts/isoboot/values.yaml
+++ b/charts/isoboot/values.yaml
@@ -68,6 +68,9 @@ squid:
   # 0 uses squid's compiled-in default (typically 256 MB).
   cacheMemMB: 0
   cacheSizeMB: 8000
+  log:
+    access: false
+    cache: true
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
## Summary
- Add `squid.log.access` (default `false`) to Helm values to toggle per-request access logging
- Cache log always writes to `/var/log/squid/cache.log` (low-volume operational messages)
- When access logging is enabled, writes to `/var/log/squid/access.log`; when disabled, uses `none`

## Test plan
- [ ] Deploy with defaults — verify no access log, cache log exists
- [ ] Deploy with `squid.log.access=true` — verify access log appears after proxy requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)