### PR TITLE
Add provision phase update endpoint

### DIFF
--- a/charts/isoboot/templates/rbac.yaml
+++ b/charts/isoboot/templates/rbac.yaml
@@ -146,6 +146,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - isoboot.github.io
+  resources:
+  - provisions/status
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -32,7 +32,11 @@ import (
 var macRegexp = regexp.MustCompile(`^([0-9a-fA-F]{2}-){5}[0-9a-fA-F]{2}$`)
 
 type bootDirectiveFunc func(ctx context.Context, mac string) (*httpd.BootDirective, error)
-type renderAutomationFunc func(ctx context.Context, provisionName, fileName string) (string, error)
+type renderAutomationFunc func(ctx context.Context, provisionName, fileName, statusURL string) (string, error)
+type updatePhaseFunc func(
+	ctx context.Context, provisionName string,
+	phase isobootgithubiov1alpha1.ProvisionPhase, message string,
+) error
 
 func main() {
 	listenAddr := flag.String("listen-addr", ":8080", "address to listen on")
@@ -94,15 +98,24 @@ func main() {
 	}, proxyPort)
 
 	renderFile := func(
-		reqCtx context.Context, provisionName, fileName string,
+		reqCtx context.Context, provisionName, fileName, statusURL string,
 	) (string, error) {
-		return httpd.RenderAutomationFile(reqCtx, c, ns, provisionName, fileName)
+		return httpd.RenderAutomationFile(reqCtx, c, ns, provisionName, fileName, statusURL)
 	}
 	automationHandler := automationFileHandler(renderFile)
+
+	updatePhase := func(
+		reqCtx context.Context, provisionName string,
+		phase isobootgithubiov1alpha1.ProvisionPhase, message string,
+	) error {
+		return httpd.UpdateProvisionPhase(reqCtx, c, ns, provisionName, phase, message)
+	}
+	statusHandler := updateStatusHandler(updatePhase)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /conditional-boot", handler)
 	mux.HandleFunc("GET /automation/{provisionName}/{fileName}", automationHandler)
+	mux.HandleFunc("POST /status", statusHandler)
 	mux.HandleFunc("GET /healthz", healthzHandler)
 
 	srv := &http.Server{
@@ -142,7 +155,9 @@ func main() {
 	}
 }
 
-func conditionalBootHandler(getDirective bootDirectiveFunc, proxyPort string) http.HandlerFunc {
+func conditionalBootHandler(
+	getDirective bootDirectiveFunc, proxyPort string,
+) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		mac := r.URL.Query().Get("mac")
 		if mac == "" {
@@ -191,6 +206,7 @@ func conditionalBootHandler(getDirective bootDirectiveFunc, proxyPort string) ht
 			}
 			baseURL := fmt.Sprintf("http://%s/dynamic/automation/%s",
 				host, directive.ProvisionName)
+			statusURL := fmt.Sprintf("http://%s/dynamic/status", host)
 			proxyURL := ""
 			if proxyPort != "" {
 				proxyURL = fmt.Sprintf("http://%s:%s", nodeIP, proxyPort)
@@ -199,6 +215,8 @@ func conditionalBootHandler(getDirective bootDirectiveFunc, proxyPort string) ht
 				directive.KernelArgs, httpd.KernelArgsData{
 					ProvisionAutomationBaseURL: baseURL,
 					ProxyURL:                   proxyURL,
+					UpdatePhaseURL:             statusURL,
+					ProvisionName:              directive.ProvisionName,
 				})
 			if err != nil {
 				slog.Error("kernel args template failed",
@@ -240,7 +258,20 @@ func automationFileHandler(render renderAutomationFunc) http.HandlerFunc {
 			return
 		}
 
-		body, err := render(r.Context(), provisionName, fileName)
+		host := r.Header.Get("X-Forwarded-Host")
+		if host == "" {
+			host = r.Host
+		}
+		if port := r.Header.Get("X-Forwarded-Port"); port != "" {
+			h, _, _ := net.SplitHostPort(host)
+			if h != "" {
+				host = h
+			}
+			host = net.JoinHostPort(host, port)
+		}
+		statusURL := fmt.Sprintf("http://%s/dynamic/status", host)
+
+		body, err := render(r.Context(), provisionName, fileName, statusURL)
 		if err != nil {
 			if httpd.IsAutomationNotFound(err) {
 				http.Error(w, "not found", http.StatusNotFound)
@@ -256,6 +287,73 @@ func automationFileHandler(render renderAutomationFunc) http.HandlerFunc {
 		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, body)
+	}
+}
+
+// allowedPhases maps phase parameter values to ProvisionPhase constants
+// and their default status messages.
+var allowedPhases = map[string]struct {
+	phase   isobootgithubiov1alpha1.ProvisionPhase
+	message string
+}{
+	"InProgress": {
+		isobootgithubiov1alpha1.ProvisionPhaseInProgress,
+		"Installation in progress",
+	},
+	"Complete": {
+		isobootgithubiov1alpha1.ProvisionPhaseComplete,
+		"Installation complete",
+	},
+}
+
+func updateStatusHandler(update updatePhaseFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		provisionName := r.FormValue("provisionName")
+		if provisionName == "" {
+			http.Error(w,
+				"missing required parameter: provisionName",
+				http.StatusBadRequest)
+			return
+		}
+		if !nameRegexp.MatchString(provisionName) ||
+			len(provisionName) > 253 {
+			http.Error(w, "invalid provision name",
+				http.StatusBadRequest)
+			return
+		}
+
+		phaseParam := r.FormValue("phase")
+		entry, ok := allowedPhases[phaseParam]
+		if !ok {
+			http.Error(w, "invalid phase: must be InProgress or Complete",
+				http.StatusBadRequest)
+			return
+		}
+
+		err := update(r.Context(), provisionName, entry.phase, entry.message)
+		if err != nil {
+			if httpd.IsProvisionNotFound(err) {
+				http.Error(w, "provision not found",
+					http.StatusNotFound)
+				return
+			}
+			if httpd.IsProvisionPhaseError(err) {
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			}
+			slog.Error("update provision status failed",
+				"provision", provisionName,
+				"phase", phaseParam, "error", err)
+			http.Error(w, "internal error",
+				http.StatusInternalServerError)
+			return
+		}
+
+		slog.Info("provision status updated",
+			"provision", provisionName, "phase", phaseParam)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "OK")
 	}
 }
 

--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -189,20 +189,10 @@ func conditionalBootHandler(
 		slog.Info("conditional-boot request", "mac", mac)
 
 		if directive.KernelArgs != "" {
-			host := r.Header.Get("X-Forwarded-Host")
-			if host == "" {
-				host = r.Host
-			}
+			host := resolveHost(r)
 			nodeIP := host
 			if h, _, err := net.SplitHostPort(nodeIP); err == nil {
 				nodeIP = h
-			}
-			if port := r.Header.Get("X-Forwarded-Port"); port != "" {
-				h, _, _ := net.SplitHostPort(host)
-				if h != "" {
-					host = h
-				}
-				host = net.JoinHostPort(host, port)
 			}
 			baseURL := fmt.Sprintf("http://%s/dynamic/automation/%s",
 				host, directive.ProvisionName)
@@ -242,6 +232,23 @@ func conditionalBootHandler(
 	}
 }
 
+// resolveHost returns the effective host:port from the request,
+// honoring X-Forwarded-Host and X-Forwarded-Port headers.
+func resolveHost(r *http.Request) string {
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	if port := r.Header.Get("X-Forwarded-Port"); port != "" {
+		h, _, _ := net.SplitHostPort(host)
+		if h != "" {
+			host = h
+		}
+		host = net.JoinHostPort(host, port)
+	}
+	return host
+}
+
 var nameRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`)
 
 func automationFileHandler(render renderAutomationFunc) http.HandlerFunc {
@@ -258,18 +265,8 @@ func automationFileHandler(render renderAutomationFunc) http.HandlerFunc {
 			return
 		}
 
-		host := r.Header.Get("X-Forwarded-Host")
-		if host == "" {
-			host = r.Host
-		}
-		if port := r.Header.Get("X-Forwarded-Port"); port != "" {
-			h, _, _ := net.SplitHostPort(host)
-			if h != "" {
-				host = h
-			}
-			host = net.JoinHostPort(host, port)
-		}
-		statusURL := fmt.Sprintf("http://%s/dynamic/status", host)
+		statusURL := fmt.Sprintf(
+			"http://%s/dynamic/status", resolveHost(r))
 
 		body, err := render(r.Context(), provisionName, fileName, statusURL)
 		if err != nil {

--- a/cmd/httpd/main_test.go
+++ b/cmd/httpd/main_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	isobootgithubiov1alpha1 "github.com/isoboot/isoboot/api/v1alpha1"
 	"github.com/isoboot/isoboot/internal/httpd"
 )
 
@@ -221,6 +222,100 @@ func TestConditionalBoot_TemplateError(t *testing.T) {
 
 	if w.Result().StatusCode != http.StatusInternalServerError {
 		t.Errorf("expected 500, got: %d", w.Result().StatusCode)
+	}
+}
+
+func noopUpdatePhase() updatePhaseFunc {
+	return func(_ context.Context, _ string,
+		_ isobootgithubiov1alpha1.ProvisionPhase, _ string,
+	) error {
+		return nil
+	}
+}
+
+func TestUpdateStatus_StatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		update     updatePhaseFunc
+		body       string
+		wantStatus int
+	}{
+		{
+			"ok InProgress",
+			noopUpdatePhase(),
+			"provisionName=my-provision&phase=InProgress",
+			http.StatusOK,
+		},
+		{
+			"ok Complete",
+			noopUpdatePhase(),
+			"provisionName=my-provision&phase=Complete",
+			http.StatusOK,
+		},
+		{
+			"wrong phase",
+			func(_ context.Context, _ string,
+				_ isobootgithubiov1alpha1.ProvisionPhase, _ string,
+			) error {
+				return fmt.Errorf(
+					"%w: cannot transition from Pending to Complete",
+					httpd.ErrInvalidPhaseTransition)
+			},
+			"provisionName=my-provision&phase=Complete",
+			http.StatusConflict,
+		},
+		{
+			"internal error",
+			func(_ context.Context, _ string,
+				_ isobootgithubiov1alpha1.ProvisionPhase, _ string,
+			) error {
+				return errors.New("connection refused")
+			},
+			"provisionName=my-provision&phase=InProgress",
+			http.StatusInternalServerError,
+		},
+		{
+			"missing provisionName",
+			noopUpdatePhase(),
+			"phase=InProgress",
+			http.StatusBadRequest,
+		},
+		{
+			"missing phase",
+			noopUpdatePhase(),
+			"provisionName=my-provision",
+			http.StatusBadRequest,
+		},
+		{
+			"invalid phase",
+			noopUpdatePhase(),
+			"provisionName=my-provision&phase=Failed",
+			http.StatusBadRequest,
+		},
+		{
+			"invalid name",
+			noopUpdatePhase(),
+			"provisionName=INVALID_NAME&phase=InProgress",
+			http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := updateStatusHandler(tt.update)
+			req := httptest.NewRequest(http.MethodPost, "/status",
+				strings.NewReader(tt.body))
+			req.Header.Set("Content-Type",
+				"application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+
+			handler(w, req)
+
+			if w.Result().StatusCode != tt.wantStatus {
+				t.Errorf("expected %d, got: %d",
+					tt.wantStatus, w.Result().StatusCode)
+			}
+		})
 	}
 }
 

--- a/cmd/httpd/main_test.go
+++ b/cmd/httpd/main_test.go
@@ -12,6 +12,9 @@ import (
 
 	isobootgithubiov1alpha1 "github.com/isoboot/isoboot/api/v1alpha1"
 	"github.com/isoboot/isoboot/internal/httpd"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func fixedDirective() bootDirectiveFunc {
@@ -263,6 +266,22 @@ func TestUpdateStatus_StatusCodes(t *testing.T) {
 			},
 			"provisionName=my-provision&phase=Complete",
 			http.StatusConflict,
+		},
+		{
+			"not found",
+			func(_ context.Context, _ string,
+				_ isobootgithubiov1alpha1.ProvisionPhase, _ string,
+			) error {
+				return fmt.Errorf("getting provision %q: %w",
+					"missing",
+					apierrors.NewNotFound(
+						schema.GroupResource{
+							Group:    "isoboot.github.io",
+							Resource: "provisions",
+						}, "missing"))
+			},
+			"provisionName=missing&phase=InProgress",
+			http.StatusNotFound,
 		},
 		{
 			"internal error",

--- a/internal/controller/indexers.go
+++ b/internal/controller/indexers.go
@@ -38,7 +38,7 @@ const ProvisionMachineRefField = "spec.machineRef"
 const MachineSpecMACField = "spec.mac"
 
 // +kubebuilder:rbac:groups=isoboot.github.io,resources=provisions,verbs=get;list;watch
-// +kubebuilder:rbac:groups=isoboot.github.io,resources=provisions/status,verbs=get
+// +kubebuilder:rbac:groups=isoboot.github.io,resources=provisions/status,verbs=get;update
 // +kubebuilder:rbac:groups=isoboot.github.io,resources=machines,verbs=get;list;watch
 // +kubebuilder:rbac:groups=isoboot.github.io,resources=bootartifacts;bootconfigs;provisionautomations,verbs=get
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=get

--- a/internal/httpd/automation.go
+++ b/internal/httpd/automation.go
@@ -37,8 +37,10 @@ var ErrFileNotFound = errors.New("file not found")
 
 // TemplateData holds the merged data passed to automation file templates.
 type TemplateData struct {
-	ConfigMaps map[string]string
-	Secrets    map[string]string
+	ConfigMaps     map[string]string
+	Secrets        map[string]string
+	UpdatePhaseURL string
+	ProvisionName  string
 }
 
 // IsAutomationNotFound reports whether err indicates a not-found condition
@@ -51,7 +53,7 @@ func IsAutomationNotFound(err error) bool {
 // ProvisionAutomation, and renders the named file template using merged
 // ConfigMap and Secret data from the Provision.
 func RenderAutomationFile(
-	ctx context.Context, c client.Client, ns, provisionName, fileName string,
+	ctx context.Context, c client.Client, ns, provisionName, fileName, statusURL string,
 ) (string, error) {
 	var provision isobootgithubiov1alpha1.Provision
 	if err := c.Get(ctx, client.ObjectKey{
@@ -80,6 +82,8 @@ func RenderAutomationFile(
 	if err != nil {
 		return "", err
 	}
+	data.UpdatePhaseURL = statusURL
+	data.ProvisionName = provisionName
 
 	tmpl, err := template.New(fileName).
 		Option("missingkey=error").Parse(tmplContent)

--- a/internal/httpd/automation_test.go
+++ b/internal/httpd/automation_test.go
@@ -79,7 +79,7 @@ var _ = Describe("RenderAutomationFile", func() {
 
 	It("returns error when provision not found", func() {
 		_, err := RenderAutomationFile(
-			ctx, k8sClient, ns, "nonexistent", "kickstart.cfg")
+			ctx, k8sClient, ns, "nonexistent", "kickstart.cfg", "")
 		Expect(err).To(MatchError(ContainSubstring("getting provision")))
 	})
 
@@ -91,7 +91,7 @@ var _ = Describe("RenderAutomationFile", func() {
 		}()
 
 		_, err := RenderAutomationFile(
-			ctx, k8sClient, ns, "ra-p1", "kickstart.cfg")
+			ctx, k8sClient, ns, "ra-p1", "kickstart.cfg", "")
 		Expect(err).To(MatchError(
 			ContainSubstring("getting provision automation")))
 	})
@@ -108,7 +108,7 @@ var _ = Describe("RenderAutomationFile", func() {
 		}()
 
 		_, err := RenderAutomationFile(
-			ctx, k8sClient, ns, "ra-p2", "missing.cfg")
+			ctx, k8sClient, ns, "ra-p2", "missing.cfg", "")
 		Expect(err).To(MatchError(ContainSubstring("missing.cfg")))
 		Expect(IsAutomationNotFound(err)).To(BeTrue())
 	})
@@ -125,7 +125,7 @@ var _ = Describe("RenderAutomationFile", func() {
 		}()
 
 		result, err := RenderAutomationFile(
-			ctx, k8sClient, ns, "ra-p3", "kickstart.cfg")
+			ctx, k8sClient, ns, "ra-p3", "kickstart.cfg", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal("lang en_US.UTF-8\nkeyboard us\n"))
 	})
@@ -148,7 +148,7 @@ var _ = Describe("RenderAutomationFile", func() {
 		}()
 
 		result, err := RenderAutomationFile(
-			ctx, k8sClient, ns, "ra-p4", "kickstart.cfg")
+			ctx, k8sClient, ns, "ra-p4", "kickstart.cfg", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(
 			"network --hostname=my-server\ntimezone UTC\n"))
@@ -171,7 +171,7 @@ var _ = Describe("RenderAutomationFile", func() {
 		}()
 
 		result, err := RenderAutomationFile(
-			ctx, k8sClient, ns, "ra-p5", "kickstart.cfg")
+			ctx, k8sClient, ns, "ra-p5", "kickstart.cfg", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal("rootpw s3cret\n"))
 	})
@@ -198,7 +198,7 @@ var _ = Describe("RenderAutomationFile", func() {
 		}()
 
 		result, err := RenderAutomationFile(
-			ctx, k8sClient, ns, "ra-p6", "kickstart.cfg")
+			ctx, k8sClient, ns, "ra-p6", "kickstart.cfg", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal("my-server UTC"))
 	})
@@ -225,8 +225,27 @@ var _ = Describe("RenderAutomationFile", func() {
 		}()
 
 		result, err := RenderAutomationFile(
-			ctx, k8sClient, ns, "ra-p7", "kickstart.cfg")
+			ctx, k8sClient, ns, "ra-p7", "kickstart.cfg", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal("specific-pw general-token"))
+	})
+
+	It("renders UpdatePhaseURL and ProvisionName", func() {
+		pa := createProvisionAutomation("ra-pa7", map[string]string{
+			"post.sh": "curl -X POST -d \"provisionName={{.ProvisionName}}&phase=Complete\" {{.UpdatePhaseURL}}",
+		})
+		p := createProvisionWithRefs(
+			"ra-p8", "ra-m8", "ra-bc8", "ra-pa7", nil, nil)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, p)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, pa)).To(Succeed())
+		}()
+
+		result, err := RenderAutomationFile(
+			ctx, k8sClient, ns, "ra-p8", "post.sh",
+			"http://10.0.0.1:8080/dynamic/status")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(
+			`curl -X POST -d "provisionName=ra-p8&phase=Complete" http://10.0.0.1:8080/dynamic/status`))
 	})
 })

--- a/internal/httpd/boot.go
+++ b/internal/httpd/boot.go
@@ -42,6 +42,8 @@ type BootDirective struct {
 type KernelArgsData struct {
 	ProvisionAutomationBaseURL string
 	ProxyURL                   string
+	UpdatePhaseURL             string
+	ProvisionName              string
 }
 
 // RenderKernelArgs renders kernel args as a Go template with the given data.

--- a/internal/httpd/boot_test.go
+++ b/internal/httpd/boot_test.go
@@ -205,6 +205,19 @@ var _ = Describe("RenderKernelArgs", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("executing kernel args template"))
 	})
+
+	It("renders UpdatePhaseURL and ProvisionName", func() {
+		result, err := RenderKernelArgs(
+			"ip=dhcp inst.ks={{.ProvisionAutomationBaseURL}}/ks.cfg inst.status={{.UpdatePhaseURL}} inst.provname={{.ProvisionName}}",
+			KernelArgsData{
+				ProvisionAutomationBaseURL: "http://10.0.0.1:8080/dynamic/automation/my-provision",
+				UpdatePhaseURL:             "http://10.0.0.1:8080/dynamic/status",
+				ProvisionName:              "my-provision",
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(ContainSubstring("inst.status=http://10.0.0.1:8080/dynamic/status"))
+		Expect(result).To(ContainSubstring("inst.provname=my-provision"))
+	})
 })
 
 var _ = Describe("IsDuplicateError", func() {

--- a/internal/httpd/provision.go
+++ b/internal/httpd/provision.go
@@ -87,9 +87,10 @@ func IsProvisionNotFound(err error) bool {
 }
 
 // IsProvisionPhaseError reports whether err indicates a phase
-// transition error.
+// transition error or a conflict from concurrent updates.
 func IsProvisionPhaseError(err error) bool {
-	return errors.Is(err, ErrInvalidPhaseTransition)
+	return errors.Is(err, ErrInvalidPhaseTransition) ||
+		apierrors.IsConflict(err)
 }
 
 // PendingProvisionForMAC returns the Provision with status.phase == Pending

--- a/internal/httpd/provision.go
+++ b/internal/httpd/provision.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	isobootgithubiov1alpha1 "github.com/isoboot/isoboot/api/v1alpha1"
@@ -33,7 +35,62 @@ var (
 	// ErrMultipleProvisions indicates more than one pending Provision
 	// exists for the same Machine.
 	ErrMultipleProvisions = errors.New("multiple pending provisions")
+	// ErrInvalidPhaseTransition indicates the requested phase transition
+	// is not allowed from the current phase.
+	ErrInvalidPhaseTransition = errors.New("invalid phase transition")
 )
+
+// validTransitions maps each target phase to its allowed source phase.
+var validTransitions = map[isobootgithubiov1alpha1.ProvisionPhase]isobootgithubiov1alpha1.ProvisionPhase{
+	isobootgithubiov1alpha1.ProvisionPhaseInProgress: isobootgithubiov1alpha1.ProvisionPhasePending,
+	isobootgithubiov1alpha1.ProvisionPhaseComplete:   isobootgithubiov1alpha1.ProvisionPhaseInProgress,
+}
+
+// UpdateProvisionPhase transitions a Provision to the given target phase.
+// It validates that the current phase allows the transition.
+func UpdateProvisionPhase(
+	ctx context.Context, c client.Client, ns, provisionName string,
+	target isobootgithubiov1alpha1.ProvisionPhase, message string,
+) error {
+	requiredSource, ok := validTransitions[target]
+	if !ok {
+		return fmt.Errorf("%w: cannot transition to %s",
+			ErrInvalidPhaseTransition, target)
+	}
+
+	var provision isobootgithubiov1alpha1.Provision
+	if err := c.Get(ctx, client.ObjectKey{
+		Name:      provisionName,
+		Namespace: ns,
+	}, &provision); err != nil {
+		return fmt.Errorf("getting provision %q: %w", provisionName, err)
+	}
+
+	if provision.Status.Phase != requiredSource {
+		return fmt.Errorf(
+			"%w: cannot transition from %s to %s",
+			ErrInvalidPhaseTransition,
+			provision.Status.Phase, target)
+	}
+
+	now := metav1.Now()
+	provision.Status.Phase = target
+	provision.Status.Message = message
+	provision.Status.LastUpdated = &now
+	return c.Status().Update(ctx, &provision)
+}
+
+// IsProvisionNotFound reports whether err indicates the Provision
+// was not found.
+func IsProvisionNotFound(err error) bool {
+	return apierrors.IsNotFound(err)
+}
+
+// IsProvisionPhaseError reports whether err indicates a phase
+// transition error.
+func IsProvisionPhaseError(err error) bool {
+	return errors.Is(err, ErrInvalidPhaseTransition)
+}
 
 // PendingProvisionForMAC returns the Provision with status.phase == Pending
 // for the Machine with the given MAC address. It returns nil if no match is

--- a/internal/httpd/provision_test.go
+++ b/internal/httpd/provision_test.go
@@ -19,6 +19,7 @@ package httpd
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	isobootgithubiov1alpha1 "github.com/isoboot/isoboot/api/v1alpha1"
 )
@@ -166,5 +167,98 @@ var _ = Describe("PendingProvisionForMAC", func() {
 			return err
 		}).Should(MatchError(ContainSubstring(
 			"multiple pending provisions")))
+	})
+})
+
+var _ = Describe("UpdateProvisionPhase", func() {
+	const ns = "default"
+
+	It("transitions Pending to InProgress", func() {
+		p := createProvision("up-p1", "up-m1", "bootconfig-1",
+			isobootgithubiov1alpha1.ProvisionPhasePending)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, p)).To(Succeed())
+		}()
+
+		Expect(UpdateProvisionPhase(ctx, k8sClient, ns, "up-p1",
+			isobootgithubiov1alpha1.ProvisionPhaseInProgress,
+			"Installation in progress")).To(Succeed())
+
+		var updated isobootgithubiov1alpha1.Provision
+		Expect(k8sClient.Get(ctx,
+			client.ObjectKeyFromObject(p), &updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(
+			isobootgithubiov1alpha1.ProvisionPhaseInProgress))
+		Expect(updated.Status.Message).To(Equal(
+			"Installation in progress"))
+		Expect(updated.Status.LastUpdated).NotTo(BeNil())
+	})
+
+	It("transitions InProgress to Complete", func() {
+		p := createProvision("up-p2", "up-m2", "bootconfig-1",
+			isobootgithubiov1alpha1.ProvisionPhaseInProgress)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, p)).To(Succeed())
+		}()
+
+		Expect(UpdateProvisionPhase(ctx, k8sClient, ns, "up-p2",
+			isobootgithubiov1alpha1.ProvisionPhaseComplete,
+			"Installation complete")).To(Succeed())
+
+		var updated isobootgithubiov1alpha1.Provision
+		Expect(k8sClient.Get(ctx,
+			client.ObjectKeyFromObject(p), &updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(
+			isobootgithubiov1alpha1.ProvisionPhaseComplete))
+		Expect(updated.Status.Message).To(Equal(
+			"Installation complete"))
+		Expect(updated.Status.LastUpdated).NotTo(BeNil())
+	})
+
+	It("rejects Pending to Complete", func() {
+		p := createProvision("up-p3", "up-m3", "bootconfig-1",
+			isobootgithubiov1alpha1.ProvisionPhasePending)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, p)).To(Succeed())
+		}()
+
+		err := UpdateProvisionPhase(ctx, k8sClient, ns, "up-p3",
+			isobootgithubiov1alpha1.ProvisionPhaseComplete, "")
+		Expect(err).To(MatchError(
+			ContainSubstring("invalid phase transition")))
+	})
+
+	It("rejects Complete to InProgress", func() {
+		p := createProvision("up-p4", "up-m4", "bootconfig-1",
+			isobootgithubiov1alpha1.ProvisionPhaseComplete)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, p)).To(Succeed())
+		}()
+
+		err := UpdateProvisionPhase(ctx, k8sClient, ns, "up-p4",
+			isobootgithubiov1alpha1.ProvisionPhaseInProgress, "")
+		Expect(err).To(MatchError(
+			ContainSubstring("invalid phase transition")))
+	})
+
+	It("rejects unsupported target phase", func() {
+		p := createProvision("up-p5", "up-m5", "bootconfig-1",
+			isobootgithubiov1alpha1.ProvisionPhasePending)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, p)).To(Succeed())
+		}()
+
+		err := UpdateProvisionPhase(ctx, k8sClient, ns, "up-p5",
+			isobootgithubiov1alpha1.ProvisionPhaseFailed, "")
+		Expect(err).To(MatchError(
+			ContainSubstring("invalid phase transition")))
+	})
+
+	It("returns error when provision not found", func() {
+		err := UpdateProvisionPhase(ctx, k8sClient, ns,
+			"up-nonexistent",
+			isobootgithubiov1alpha1.ProvisionPhaseInProgress, "")
+		Expect(err).To(HaveOccurred())
+		Expect(IsProvisionNotFound(err)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
## Summary

Closes #353.

- Add `POST /status` endpoint (nginx: `/dynamic/status`) to update Provision phase
- Accepts `provisionName` and `phase` (InProgress or Complete) as POST body params
- Enforces valid transitions: Pending -> InProgress -> Complete
- Expose `{{.UpdatePhaseURL}}` and `{{.ProvisionName}}` template variables in kernel args and automation file templates
- Grant httpd RBAC `provisions/status` update permission

Kickstart usage:
- `%pre`: `curl -X POST -d "provisionName={{.ProvisionName}}&phase=InProgress" {{.UpdatePhaseURL}}`
- `%post`: `curl -X POST -d "provisionName={{.ProvisionName}}&phase=Complete" {{.UpdatePhaseURL}}`

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `UpdateProvisionPhase` tests: valid transitions, rejected transitions, not found
- [x] `updateStatusHandler` tests: 200/400/404/409/500 status codes
- [x] Template rendering tests for `{{.UpdatePhaseURL}}` and `{{.ProvisionName}}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)