### PR TITLE
Add machine-id and virtio checks

### DIFF
--- a/.github/workflows/test-provision-e2e.yaml
+++ b/.github/workflows/test-provision-e2e.yaml
@@ -675,13 +675,13 @@ jobs:
 
         # (f) Verify /etc/machine-id matches generated value
         EXPECTED_MID=$(cat /tmp/machine-id)
-        ACTUAL_MID=$(ssh -i /tmp/e2e-ssh-key $SSH_OPTS isoboot@"$VM_IP" \
-          'head -c 32 /etc/machine-id')
-        echo "machine-id: expected=$EXPECTED_MID actual=$ACTUAL_MID"
+        MID_INFO=$(ssh -i /tmp/e2e-ssh-key $SSH_OPTS isoboot@"$VM_IP" \
+          'printf "%s %s" "$(head -c 32 /etc/machine-id)" "$(wc -c < /etc/machine-id)"')
+        ACTUAL_MID=${MID_INFO% *}
+        MID_LEN=${MID_INFO#* }
+        echo "machine-id: expected=$EXPECTED_MID actual=$ACTUAL_MID len=$MID_LEN"
         [ "$EXPECTED_MID" = "$ACTUAL_MID" ] \
           || { echo "FAIL: machine-id mismatch"; exit 1; }
-        MID_LEN=$(ssh -i /tmp/e2e-ssh-key $SSH_OPTS isoboot@"$VM_IP" \
-          'wc -c < /etc/machine-id')
         [ "$MID_LEN" = "33" ] \
           || { echo "FAIL: /etc/machine-id should be 33 bytes (32 hex + newline), got $MID_LEN"; exit 1; }
         echo "PASS: machine-id"

--- a/.github/workflows/test-provision-e2e.yaml
+++ b/.github/workflows/test-provision-e2e.yaml
@@ -324,6 +324,7 @@ jobs:
         ssh-keygen -t ed25519 -N "" -f /tmp/ssh_host_ed25519_key
         ssh-keygen -t rsa -b 4096 -N "" -f /tmp/ssh_host_rsa_key
         openssl passwd -6 "e2etest" > /tmp/encrypted-password
+        head -c 16 /dev/urandom | xxd -p > /tmp/machine-id
 
     # ── Create provisioning resources ──────────────────────────────
     - name: Create ConfigMap and Secret
@@ -331,7 +332,8 @@ jobs:
         kubectl -n isoboot-system create configmap default-user \
           --from-literal="default_user.username=isoboot" \
           --from-literal="default_user.password=$(cat /tmp/encrypted-password)" \
-          --from-literal="default_user.ssh_public_key=$(cat /tmp/e2e-ssh-key.pub)"
+          --from-literal="default_user.ssh_public_key=$(cat /tmp/e2e-ssh-key.pub)" \
+          --from-literal="machine_id=$(cat /tmp/machine-id)"
 
         kubectl -n isoboot-system create secret generic host-keys \
           --from-file=ssh_host_ecdsa_key=/tmp/ssh_host_ecdsa_key \
@@ -407,6 +409,11 @@ jobs:
               {{- end }}
               sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
               sed -i '/\/boot\/efi/s/defaults/defaults,nofail/' /etc/fstab
+              {{- if index .ConfigMaps "machine_id" }}
+              printf '%s\n' '{{ index .ConfigMaps "machine_id" }}' > /etc/machine-id
+              chmod 444 /etc/machine-id
+              restorecon /etc/machine-id
+              {{- end }}
               curl -X POST -d "provisionName={{.ProvisionName}}&phase=Complete" {{.UpdatePhaseURL}}
               %end
         ---
@@ -665,6 +672,27 @@ jobs:
         [ "$OS_VERSION" = "${{ matrix.version }}" ] \
           || { echo "FAIL: expected version ${{ matrix.version }}, got $OS_VERSION"; exit 1; }
         echo "PASS: OS identity"
+
+        # (f) Verify /etc/machine-id matches generated value
+        EXPECTED_MID=$(cat /tmp/machine-id)
+        ACTUAL_MID=$(ssh -i /tmp/e2e-ssh-key $SSH_OPTS isoboot@"$VM_IP" \
+          'head -c 32 /etc/machine-id')
+        echo "machine-id: expected=$EXPECTED_MID actual=$ACTUAL_MID"
+        [ "$EXPECTED_MID" = "$ACTUAL_MID" ] \
+          || { echo "FAIL: machine-id mismatch"; exit 1; }
+        MID_LEN=$(ssh -i /tmp/e2e-ssh-key $SSH_OPTS isoboot@"$VM_IP" \
+          'wc -c < /etc/machine-id')
+        [ "$MID_LEN" = "33" ] \
+          || { echo "FAIL: /etc/machine-id should be 33 bytes (32 hex + newline), got $MID_LEN"; exit 1; }
+        echo "PASS: machine-id"
+
+        # (g) Verify OS is installed on virtio disk (/dev/vda)
+        ROOT_DEV=$(ssh -i /tmp/e2e-ssh-key $SSH_OPTS isoboot@"$VM_IP" \
+          "findmnt -n -o SOURCE /")
+        echo "Root device: $ROOT_DEV"
+        echo "$ROOT_DEV" | grep -q "^/dev/vda" \
+          || { echo "FAIL: root not on virtio disk, got $ROOT_DEV"; exit 1; }
+        echo "PASS: OS on virtio /dev/vda"
 
         echo "All SSH verifications passed!"
 


### PR DESCRIPTION
## Summary
- Generate random machine-id, inject via ConfigMap, write to `/etc/machine-id` in kickstart %post
- Verify machine-id matches (32 hex chars + newline = 33 bytes)
- Verify OS root filesystem is on virtio disk (`/dev/vda`)

## Test plan
- [x] Workflow run passed all 4 matrix jobs: [run 23360918581](https://github.com/isoboot/isoboot/actions/runs/23360918581)
  - Alma 10.1: machine-id `f99e10b5...` ✓, root `/dev/vda4` ✓
  - Alma 9.7: machine-id `1505ef0b...` ✓, root `/dev/vda4` ✓
  - Rocky 10.1: machine-id `ee8cc554...` ✓, root `/dev/vda4` ✓
  - Rocky 9.7: machine-id `328dd7f4...` ✓, root `/dev/vda4` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)