### PR TITLE
Simplify E2E kickstart for single-disk VM

### DIFF
--- a/.github/workflows/test-provision-e2e.yaml
+++ b/.github/workflows/test-provision-e2e.yaml
@@ -363,7 +363,7 @@ jobs:
               autopart --type=plain
               clearpart --all --initlabel
               zerombr
-              bootloader --location=mbr --boot-drive=vda
+              bootloader --location=mbr
               user --name={{ index .ConfigMaps "default_user.username" }} --groups=wheel --iscrypted --password={{ index .ConfigMaps "default_user.password" }}
               {{- if index .ConfigMaps "default_user.ssh_public_key" }}
               sshkey --username={{ index .ConfigMaps "default_user.username" }} "{{ index .ConfigMaps "default_user.ssh_public_key" }}"

--- a/.github/workflows/test-provision-e2e.yaml
+++ b/.github/workflows/test-provision-e2e.yaml
@@ -405,6 +405,7 @@ jobs:
               restorecon /etc/ssh/ssh_host_rsa_key.pub
               {{- end }}
               sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+              sed -i '/\/boot\/efi/s/defaults/defaults,nofail/' /etc/fstab
               curl -X POST -d "provisionName={{.ProvisionName}}&phase=Complete" {{.UpdatePhaseURL}}
               %end
         ---

--- a/.github/workflows/test-provision-e2e.yaml
+++ b/.github/workflows/test-provision-e2e.yaml
@@ -355,7 +355,6 @@ jobs:
         spec:
           files:
             ks.cfg: |
-              text
               lang en_US.UTF-8
               keyboard us
               timezone America/Los_Angeles --utc
@@ -406,7 +405,6 @@ jobs:
               restorecon /etc/ssh/ssh_host_rsa_key.pub
               {{- end }}
               sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
-              sed -i '/\/boot\/efi/s/defaults/defaults,nofail/' /etc/fstab
               curl -X POST -d "provisionName={{.ProvisionName}}&phase=Complete" {{.UpdatePhaseURL}}
               %end
         ---

--- a/.github/workflows/test-provision-e2e.yaml
+++ b/.github/workflows/test-provision-e2e.yaml
@@ -358,7 +358,6 @@ jobs:
               lang en_US.UTF-8
               keyboard us
               timezone America/Los_Angeles --utc
-              ignoredisk --only-use=vda
               autopart --type=plain
               clearpart --all --initlabel
               zerombr

--- a/.github/workflows/test-provision-e2e.yaml
+++ b/.github/workflows/test-provision-e2e.yaml
@@ -372,10 +372,6 @@ jobs:
               eula --agreed
               reboot
 
-              %packages
-              @core
-              %end
-
               %pre --log=/var/log/kickstart-pre.log
               curl -X POST -d "provisionName={{.ProvisionName}}&phase=InProgress" {{.UpdatePhaseURL}}
               %end

--- a/.github/workflows/test-provision-e2e.yaml
+++ b/.github/workflows/test-provision-e2e.yaml
@@ -360,7 +360,7 @@ jobs:
               timezone America/Los_Angeles --utc
               ignoredisk --only-use=vda
               autopart --type=plain
-              clearpart --all --initlabel --drives=vda
+              clearpart --all --initlabel
               zerombr
               bootloader --location=mbr --boot-drive=vda
               user --name={{ index .ConfigMaps "default_user.username" }} --groups=wheel --iscrypted --password={{ index .ConfigMaps "default_user.password" }}


### PR DESCRIPTION
## Summary
- Remove `text` from kickstart — irrelevant with no display attached
- Remove `ignoredisk --only-use=vda` — redundant with only one disk
- Remove `--drives=vda` from `clearpart` — single disk is the default target
- Remove `--boot-drive=vda` from `bootloader` — same reasoning
- Remove `%packages @core %end` — Anaconda defaults to `@core` without it
- Retain `nofail` fstab sed — needed for Alma to boot from disk

## Test plan
- [x] [E2E workflow passed](https://github.com/isoboot/isoboot/actions/runs/23396789338)

🤖 Generated with [Claude Code](https://claude.com/claude-code)