### PR TITLE
Log MAC for unprovisioned PXE boots

### DIFF
--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -182,6 +182,7 @@ func conditionalBootHandler(
 		}
 
 		if directive == nil {
+			slog.Info("no pending provision", "mac", mac)
 			http.Error(w, "no pending provision for MAC", http.StatusNotFound)
 			return
 		}


### PR DESCRIPTION
## Summary
- Log the MAC address at `info` level when a PXE boot request has no matching pending provision, aiding visibility into unknown/unprovisioned machines hitting the server.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [ ] Deploy and verify log output for a PXE boot from an unprovisioned MAC

🤖 Generated with [Claude Code](https://claude.com/claude-code)