### PR TITLE
Add Debian 13 firmware example

### DIFF
--- a/examples/debian-13-firmware.yaml
+++ b/examples/debian-13-firmware.yaml
@@ -1,0 +1,28 @@
+apiVersion: isoboot.github.io/v1alpha1
+kind: BootArtifact
+metadata:
+  name: debian-13-firmware
+  labels:
+    app.kubernetes.io/name: isoboot
+spec:
+  url: https://cdimage.debian.org/cdimage/firmware/trixie/13.4.0/firmware.cpio.gz
+  sha512: "34bf22416440c33e27541285b912acae157c2ef4767030e4f24ff99dad6560664807e7ea3617638be492a4a55d079df79500a701f3b0ccbc728d01d4e96c7092"
+---
+# Firmware-enabled BootConfig for Debian 13.
+# Apply together with debian-13.yaml (provides the kernel and initrd artifacts).
+# The controller concatenates initrd.gz + firmware.cpio.gz so the Debian installer
+# can detect and deploy non-free firmware (e.g. for Intel PRO/100, Realtek RTL8168/8125).
+apiVersion: isoboot.github.io/v1alpha1
+kind: BootConfig
+metadata:
+  name: debian-13-firmware
+  labels:
+    app.kubernetes.io/name: isoboot
+spec:
+  kernel:
+    ref: debian-13-kernel
+    args: "console=ttyS0,115200 auto=true priority=critical {{if .ProxyURL}}mirror/http/proxy={{.ProxyURL}} {{end}}preseed/url={{.ProvisionAutomationBaseURL}}/preseed.cfg"
+  initrd:
+    ref: debian-13-initrd
+  firmware:
+    ref: debian-13-firmware


### PR DESCRIPTION
## Summary

- Adds `debian-13-firmware` BootArtifact pointing to Debian's `firmware.cpio.gz` (pinned to 13.4.0)
- Adds `debian-13-firmware` BootConfig that references the existing kernel/initrd from `debian-13.yaml` plus the firmware artifact
- The controller concatenates `initrd.gz + firmware.cpio.gz` so the Debian installer can detect and deploy non-free firmware (e.g., Intel PRO/100 `e100`, Realtek RTL8168/8125 `r8169`)

Closes #369

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Apply `debian-13.yaml` + `debian-13-firmware.yaml` and verify BootConfig reaches Ready with concatenated initrd

🤖 Generated with [Claude Code](https://claude.com/claude-code)