### PR TITLE
Mode B: serve the ISO over HTTP for installer root fs

### DIFF
--- a/cmd/httpd/main.go
+++ b/cmd/httpd/main.go
@@ -202,12 +202,17 @@ func conditionalBootHandler(
 			if proxyPort != "" {
 				proxyURL = fmt.Sprintf("http://%s:%s", nodeIP, proxyPort)
 			}
+			isoURL := ""
+			if directive.ISOPath != "" {
+				isoURL = fmt.Sprintf("http://%s/static/%s", host, directive.ISOPath)
+			}
 			rendered, err := httpd.RenderKernelArgs(
 				directive.KernelArgs, httpd.KernelArgsData{
 					ProvisionAutomationBaseURL: baseURL,
 					ProxyURL:                   proxyURL,
 					UpdatePhaseURL:             statusURL,
 					ProvisionName:              directive.ProvisionName,
+					ISOURL:                     isoURL,
 				})
 			if err != nil {
 				slog.Error("kernel args template failed",

--- a/internal/controller/bootconfig_controller.go
+++ b/internal/controller/bootconfig_controller.go
@@ -201,10 +201,11 @@ func (r *BootConfigReconciler) reconcileISO(ctx context.Context, bc *isobootgith
 		return r.setError(ctx, bc, fmt.Sprintf("extracting from iso: %v", err))
 	}
 
-	// Serve the ISO itself (as image.iso) so installers can fetch their root
-	// filesystem over HTTP. Sibling-safe so it doesn't disturb vmlinuz/initrd.
+	// Serve the ISO itself (under its own filename) so installers can fetch
+	// their root filesystem over HTTP. Sibling-safe so it doesn't disturb
+	// the extracted vmlinuz/initrd.
 	isoTarget := filepath.Join("..", "..", "artifacts", isoArtifact.Name, isoFilename)
-	if err := ensureFileSymlink(filepath.Join(bootDir, "image.iso"), isoTarget); err != nil {
+	if err := ensureFileSymlink(filepath.Join(bootDir, isoFilename), isoTarget); err != nil {
 		return r.setError(ctx, bc, fmt.Sprintf("creating iso symlink: %v", err))
 	}
 

--- a/internal/controller/bootconfig_controller.go
+++ b/internal/controller/bootconfig_controller.go
@@ -201,10 +201,27 @@ func (r *BootConfigReconciler) reconcileISO(ctx context.Context, bc *isobootgith
 		return r.setError(ctx, bc, fmt.Sprintf("extracting from iso: %v", err))
 	}
 
+	// Serve the ISO itself (as image.iso) so installers can fetch their root
+	// filesystem over HTTP. Sibling-safe so it doesn't disturb vmlinuz/initrd.
+	isoTarget := filepath.Join("..", "..", "artifacts", isoArtifact.Name, isoFilename)
+	if err := ensureFileSymlink(filepath.Join(bootDir, "image.iso"), isoTarget); err != nil {
+		return r.setError(ctx, bc, fmt.Sprintf("creating iso symlink: %v", err))
+	}
+
 	if bc.Status.Phase != isobootgithubiov1alpha1.BootConfigPhaseReady {
 		log.Info("BootConfig assembled from ISO", "name", bc.Name, "bootDir", bootDir)
 	}
 	return r.setReady(ctx, bc)
+}
+
+// ensureFileSymlink idempotently points link at target without disturbing
+// sibling entries (unlike ensureSymlink, which manages a whole directory).
+func ensureFileSymlink(link, target string) error {
+	if existing, err := os.Readlink(link); err == nil && existing == target {
+		return nil
+	}
+	_ = os.Remove(link)
+	return os.Symlink(target, link)
 }
 
 // maxExtractedFileSize caps an individual file extracted from an ISO, guarding

--- a/internal/controller/bootconfig_iso_test.go
+++ b/internal/controller/bootconfig_iso_test.go
@@ -162,7 +162,7 @@ var _ = Describe("BootConfig Controller ISO mode", func() {
 
 		// The ISO is also served as image.iso — a sibling symlink to the artifact
 		// that resolves to the real file (so installers can fetch their root fs).
-		isoLink := filepath.Join(dataDir, "boot", "iso-bc-ok", "image.iso")
+		isoLink := filepath.Join(dataDir, "boot", "iso-bc-ok", "test.iso")
 		target, err := os.Readlink(isoLink)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(target).To(Equal(filepath.Join("..", "..", "artifacts", "iso-ok", "test.iso")))
@@ -189,6 +189,11 @@ var _ = Describe("BootConfig Controller ISO mode", func() {
 		after, err := os.Stat(vmlinuzPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.SameFile(before, after)).To(BeTrue())
+
+		// The ISO symlink is also stable across reconciles.
+		isoTarget, err := os.Readlink(filepath.Join(dataDir, "boot", "iso-bc-idem", "test.iso"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isoTarget).To(Equal(filepath.Join("..", "..", "artifacts", "iso-idem", "test.iso")))
 	})
 
 	It("is Pending when the ISO artifact is not Ready", func() {

--- a/internal/controller/bootconfig_iso_test.go
+++ b/internal/controller/bootconfig_iso_test.go
@@ -159,6 +159,16 @@ var _ = Describe("BootConfig Controller ISO mode", func() {
 		initrd, err := os.ReadFile(filepath.Join(dataDir, "boot", "iso-bc-ok", "initrd"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(initrd)).To(Equal("INITRD-BYTES"))
+
+		// The ISO is also served as image.iso — a sibling symlink to the artifact
+		// that resolves to the real file (so installers can fetch their root fs).
+		isoLink := filepath.Join(dataDir, "boot", "iso-bc-ok", "image.iso")
+		target, err := os.Readlink(isoLink)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(target).To(Equal(filepath.Join("..", "..", "artifacts", "iso-ok", "test.iso")))
+		info, err := os.Stat(isoLink) // follows the symlink
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeFalse())
 	})
 
 	It("does not re-extract on repeated reconcile when up to date", func() {

--- a/internal/controller/bootconfig_iso_test.go
+++ b/internal/controller/bootconfig_iso_test.go
@@ -160,8 +160,8 @@ var _ = Describe("BootConfig Controller ISO mode", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(initrd)).To(Equal("INITRD-BYTES"))
 
-		// The ISO is also served as image.iso — a sibling symlink to the artifact
-		// that resolves to the real file (so installers can fetch their root fs).
+		// The ISO is also served under its own filename — a sibling symlink to the
+		// artifact that resolves to the real file (so installers can fetch root fs).
 		isoLink := filepath.Join(dataDir, "boot", "iso-bc-ok", "test.iso")
 		target, err := os.Readlink(isoLink)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/httpd/boot.go
+++ b/internal/httpd/boot.go
@@ -35,6 +35,7 @@ type BootDirective struct {
 	KernelPath    string
 	KernelArgs    string
 	InitrdPath    string
+	ISOPath       string
 	ProvisionName string
 }
 
@@ -44,6 +45,7 @@ type KernelArgsData struct {
 	ProxyURL                   string
 	UpdatePhaseURL             string
 	ProvisionName              string
+	ISOURL                     string
 }
 
 // RenderKernelArgs renders kernel args as a Go template with the given data.
@@ -96,6 +98,7 @@ func BootDirectiveForMAC(
 			KernelPath:    path.Join(bc.Name, "vmlinuz"),
 			KernelArgs:    bc.Spec.KernelArgs,
 			InitrdPath:    path.Join(bc.Name, "initrd"),
+			ISOPath:       path.Join(bc.Name, "image.iso"),
 			ProvisionName: provision.Name,
 		}, nil
 	}

--- a/internal/httpd/boot.go
+++ b/internal/httpd/boot.go
@@ -94,11 +94,20 @@ func BootDirectiveForMAC(
 
 	// Mode B (ISO): kernel and initrd are extracted to fixed filenames.
 	if bc.Spec.ISO != nil {
+		var isoArtifact isobootgithubiov1alpha1.BootArtifact
+		if err := c.Get(ctx, client.ObjectKey{
+			Name:      bc.Spec.ISO.ArtifactRef,
+			Namespace: ns,
+		}, &isoArtifact); err != nil {
+			return nil, fmt.Errorf("getting iso artifact %q: %w",
+				bc.Spec.ISO.ArtifactRef, err)
+		}
+		isoFile := urlutil.FilenameFromURL(isoArtifact.Spec.URL)
 		return &BootDirective{
 			KernelPath:    path.Join(bc.Name, "vmlinuz"),
 			KernelArgs:    bc.Spec.KernelArgs,
 			InitrdPath:    path.Join(bc.Name, "initrd"),
-			ISOPath:       path.Join(bc.Name, "image.iso"),
+			ISOPath:       path.Join(bc.Name, isoFile),
 			ProvisionName: provision.Name,
 		}, nil
 	}

--- a/internal/httpd/boot_test.go
+++ b/internal/httpd/boot_test.go
@@ -161,7 +161,7 @@ var _ = Describe("BootDirectiveForMAC", func() {
 
 		Expect(result.KernelPath).To(Equal("bd-bc3/vmlinuz"))
 		Expect(result.InitrdPath).To(Equal("bd-bc3/initrd"))
-		Expect(result.ISOPath).To(Equal("bd-bc3/image.iso"))
+		Expect(result.ISOPath).To(Equal("bd-bc3/ubuntu.iso"))
 		Expect(result.KernelArgs).To(Equal("autoinstall ds=nocloud-net"))
 		Expect(result.ProvisionName).To(Equal("bd-p4"))
 	})
@@ -260,11 +260,11 @@ var _ = Describe("RenderKernelArgs", func() {
 			"ip=dhcp url={{.ISOURL}} autoinstall ds=nocloud-net;s={{.ProvisionAutomationBaseURL}}/",
 			KernelArgsData{
 				ProvisionAutomationBaseURL: "http://10.0.0.1:8080/dynamic/automation/my-provision",
-				ISOURL:                     "http://10.0.0.1:8080/static/ubuntu-26.04/image.iso",
+				ISOURL:                     "http://10.0.0.1:8080/static/ubuntu-26.04/ubuntu-26.04-live-server-amd64.iso",
 			})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(
-			"ip=dhcp url=http://10.0.0.1:8080/static/ubuntu-26.04/image.iso autoinstall ds=nocloud-net;s=http://10.0.0.1:8080/dynamic/automation/my-provision/"))
+			"ip=dhcp url=http://10.0.0.1:8080/static/ubuntu-26.04/ubuntu-26.04-live-server-amd64.iso autoinstall ds=nocloud-net;s=http://10.0.0.1:8080/dynamic/automation/my-provision/"))
 	})
 })
 

--- a/internal/httpd/boot_test.go
+++ b/internal/httpd/boot_test.go
@@ -161,6 +161,7 @@ var _ = Describe("BootDirectiveForMAC", func() {
 
 		Expect(result.KernelPath).To(Equal("bd-bc3/vmlinuz"))
 		Expect(result.InitrdPath).To(Equal("bd-bc3/initrd"))
+		Expect(result.ISOPath).To(Equal("bd-bc3/image.iso"))
 		Expect(result.KernelArgs).To(Equal("autoinstall ds=nocloud-net"))
 		Expect(result.ProvisionName).To(Equal("bd-p4"))
 	})
@@ -252,6 +253,18 @@ var _ = Describe("RenderKernelArgs", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(ContainSubstring("inst.status=http://10.0.0.1:8080/dynamic/status"))
 		Expect(result).To(ContainSubstring("inst.provname=my-provision"))
+	})
+
+	It("renders ISOURL for ISO-mode autoinstall", func() {
+		result, err := RenderKernelArgs(
+			"ip=dhcp url={{.ISOURL}} autoinstall ds=nocloud-net;s={{.ProvisionAutomationBaseURL}}/",
+			KernelArgsData{
+				ProvisionAutomationBaseURL: "http://10.0.0.1:8080/dynamic/automation/my-provision",
+				ISOURL:                     "http://10.0.0.1:8080/static/ubuntu-26.04/image.iso",
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(
+			"ip=dhcp url=http://10.0.0.1:8080/static/ubuntu-26.04/image.iso autoinstall ds=nocloud-net;s=http://10.0.0.1:8080/dynamic/automation/my-provision/"))
 	})
 })
 


### PR DESCRIPTION
## Summary

Enhances BootConfig **Mode B** so isoboot serves the source ISO itself, not just the extracted kernel/initrd. This lets a netbooted installer fetch its **root filesystem** over HTTP from isoboot — required for Ubuntu live-server (casper), where PXE-booting the extracted `casper/vmlinuz` + `casper/initrd` isn't enough; casper still needs `filesystem.squashfs` from the ISO.

Enabler for #376 (Ubuntu 26.04 autoinstall E2E).

## Changes

- **Controller** (`reconcileISO`): after extracting vmlinuz/initrd, symlink the ISO into the boot dir under **its own filename** (from the URL) → served at `/static/{name}/{iso-filename}`. Uses a new **sibling-safe** `ensureFileSymlink` helper (the existing `ensureSymlink` wipes the whole directory, which would delete the extracted vmlinuz/initrd on the flat Mode B boot dir).
- **Boot directive** (`boot.go`): Mode B now looks up the ISO artifact to derive the served filename and sets `ISOPath` (`{name}/{iso-filename}`); adds an `ISOURL` field to `KernelArgsData`.
- **httpd** (`main.go`): render `ISOURL` to the absolute served ISO URL (`http://{host}/static/{name}/{iso-filename}`), using the request host like the existing `ProvisionAutomationBaseURL`.
- New kernel-args template variable **`{{.ISOURL}}`**, e.g. `kernelArgs: "ip=dhcp url={{.ISOURL}} autoinstall …"`.

## Test plan

- `make test` — controller 75.3%, httpd 86.5%; tests cover the Mode B directive `ISOPath`, the controller creating the ISO symlink (resolving to the real file) + its stability across reconciles, and `{{.ISOURL}}` rendering.
- `make lint` — 0 issues. No CRD/codegen changes (internal structs + a template var only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)